### PR TITLE
Fix stream position after parsing an unskippable chunk

### DIFF
--- a/src/ManiaPlanetSharp/GameBox/GameBoxFile.cs
+++ b/src/ManiaPlanetSharp/GameBox/GameBoxFile.cs
@@ -338,6 +338,7 @@ namespace ManiaPlanetSharp.GameBox
                             else
                             {
                                 chunks.Add(parser.Parse(reader, id));
+                                offset = stream.Position;
                             }
 
                         }


### PR DESCRIPTION
This fixes my problems with chunk `MapCheckpointsChunk` and also some other problems as well. Comparing pybgx with MP# master yielded strange behaviour where `GameBoxFile` that's main class is a replay class would parse map related chunks. Replay files contain the embedded GBX map and while entering the unskippable chunk that contains map data, MP# would delegate parsing it to another `GameBoxFile` instance but itself would not advance the offset that was read with the stream reader. 

This resulted in the main replay parser trying to parse the compressed map file data and therefore stumbling upon chunk ID's that were known but happened to be partially compressed. After reading the chunk ID of `MapCheckpointsChunk`, it would read the skip size the checkpoint count which were both compressed and the parser would skip to the end of the file, since the chunk is skippable.

This also fixes some cases with replays with a lot of ghosts where the parser would indefinitely grow in memory size.

The case-less version of this is:
* skippable chunks were properly skipped because their size was known
* unskippable chunks were properly parsed, but the final stream position after parsing a chunk was not advanced in the global offset