### PR TITLE
Make game version a long string

### DIFF
--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Ghost/GhostChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Ghost/GhostChunk.cs
@@ -30,7 +30,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
         [Property, Array(nameof(ControlEntryCount))]
         public GhostControlEntry[] ControlEntries { get; set; }
 
-        [Property]
+        [Property(SpecialPropertyType.LongString)]
         public string GameVersion { get; set; }
 
         [Property]

--- a/src/ManiaPlanetSharp/GameBox/Parsing/ParserGeneration/Attributes/PropertyAttribute.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/ParserGeneration/Attributes/PropertyAttribute.cs
@@ -9,6 +9,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing
     {
         LookbackString,
         NodeReference,
+        LongString,
         //CustomStruct
     }
 

--- a/src/ManiaPlanetSharp/GameBox/Parsing/ParserGeneration/ParserCodeGenerator.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/ParserGeneration/ParserCodeGenerator.cs
@@ -105,6 +105,14 @@ namespace ManiaPlanetSharp.GameBox.Parsing.ParserGeneration
                         }
                         parseCode = "reader.ReadLookbackString()";
                         break;
+                    case SpecialPropertyType.LongString:
+                        if (singleValueType != typeof(string))
+                        {
+                            throw new InvalidOperationException($"Property marked as longstring is not of type string at {field.Property.DeclaringType.Name}.{field.Property.Name}.");
+                        }
+
+                        parseCode = "reader.ReadLongString()";
+                        break;
                     case SpecialPropertyType.NodeReference:
                         if (!typeof(Node).IsAssignableFrom(singleValueType))
                         {

--- a/src/ManiaPlanetSharp/GameBox/Parsing/ParserGeneration/ParserGenerator.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/ParserGeneration/ParserGenerator.cs
@@ -221,6 +221,13 @@ namespace ManiaPlanetSharp.GameBox.Parsing.ParserGeneration
                         }
                         //reader.ReadLookbackString();
                         return Expression.Call(reader, nameof(GameBoxReader.ReadLookbackString), null);
+                    case SpecialPropertyType.LongString:
+                        if (singleValueType != typeof(string))
+                        {
+                            throw new InvalidOperationException($"Property marked as longstring is not of type string at {field.Property.DeclaringType.Name}.{field.Property.Name}.");
+                        }
+
+                        return Expression.Call(reader, nameof(GameBoxReader.ReadLongString), null);
                     case SpecialPropertyType.NodeReference:
                         if (!typeof(Node).IsAssignableFrom(singleValueType))
                         {


### PR DESCRIPTION
This is needed for very long replay files with the competition patch. The parser would fail to parse CP data, as the encoded string was longer than the max string limit. This adds a new special property that allows the use of `ReadLongString()`.