### PR TITLE
Set empty times (unvalidated maps etc) to null instead of int.maxvalue/-1

### DIFF
--- a/src/ManiaPlanetSharp/GameBox/MetadataProviders/MapMetadataProvider.cs
+++ b/src/ManiaPlanetSharp/GameBox/MetadataProviders/MapMetadataProvider.cs
@@ -69,6 +69,14 @@ namespace ManiaPlanetSharp.GameBox.MetadataProviders
 
         public virtual bool? Validated => this.GetBufferedHeaderValue((MapCommunityChunk c) => c.Root?.Description?.Validated);
 
+        /// <summary>
+        /// Infers the validation state of the map. For pre-ManiaPlanet maps, the validation state can not be read from the file directly and has to be inferred from the presence of an author time instead.
+        /// </summary>
+        public virtual bool InferValidationState()
+        {
+            return this.Validated ?? this.AuthorTime != null;
+        }
+
         public virtual string TypeFull => this.GetBufferedHeaderValue((MapCommonChunk c) => c.Type)
             .IgnoreIfEmpty();
 

--- a/src/ManiaPlanetSharp/GameBox/MetadataProviders/MetadataProvider.cs
+++ b/src/ManiaPlanetSharp/GameBox/MetadataProviders/MetadataProvider.cs
@@ -264,7 +264,7 @@ namespace ManiaPlanetSharp.GameBox.MetadataProviders
                         }
                     }
                 }
-                return default;
+                return default(TValue);
             }
         }
 
@@ -303,7 +303,7 @@ namespace ManiaPlanetSharp.GameBox.MetadataProviders
                         }
                     }
                 }
-                return default;
+                return default(TValue);
             }
         }
     }

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapCommunityChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapCommunityChunk.cs
@@ -47,7 +47,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
                 ExecutableVersion = document.Root.Attribute("exever")?.Value,
                 ExecutableBuildDate = document.Root.Attribute("exebuild")?.Value,
                 Title = document.Root.Attribute("title")?.Value,
-                Lightmap = int.TryParse(document.Root.Attribute("lightmap")?.Value ?? string.Empty, out int i0) ? i0 : 0
+                Lightmap = int.TryParse(document.Root.Attribute("lightmap")?.Value ?? string.Empty, out int i0) ? (int?)i0 : null
             };
 
             var identity = document.Root.Element("ident");
@@ -72,11 +72,11 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
                     Type = description.Attribute("type")?.Value,
                     MapType = description.Attribute("maptype")?.Value,
                     MapStyle = description.Attribute("mapstyle")?.Value,
-                    Validated = description.Attribute("validated")?.Value == "1",
-                    LapCount = int.TryParse(description.Attribute("nblaps")?.Value ?? string.Empty, out int i1) ? i1 : 0,
-                    DisplayCost = int.TryParse(description.Attribute("displaycost")?.Value ?? string.Empty, out int i2) ? i2 : 0,
+                    Validated = description.Attribute("validated") != null ? (bool?)(description.Attribute("validated").Value == "1") : null,
+                    LapCount = int.TryParse(description.Attribute("nblaps")?.Value ?? string.Empty, out int i1) ? (int?)i1 : null,
+                    DisplayCost = int.TryParse(description.Attribute("displaycost")?.Value ?? string.Empty, out int i2) ? (int?)i2 : null,
                     Mod = description.Attribute("mod")?.Value,
-                    HasGhostBlocks = description.Attribute("hasghostblocks")?.Value == "1"
+                    HasGhostBlocks = description.Attribute("hasghostblocks") != null ? (bool?)(description.Attribute("hasghostblocks").Value == "1") : null
                 };
             }
 
@@ -94,11 +94,11 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
             {
                 root.Times = new MapCommunityTimes()
                 {
-                    Bronze = int.TryParse(times.Attribute("bronze")?.Value ?? string.Empty, out int i1) ? i1 : 0,
-                    Silver = int.TryParse(times.Attribute("silver")?.Value ?? string.Empty, out int i2) ? i2 : 0,
-                    Gold = int.TryParse(times.Attribute("gold")?.Value ?? string.Empty, out int i3) ? i3 : 0,
-                    AuthorTime = int.TryParse(times.Attribute("authortime")?.Value ?? string.Empty, out int i4) ? i4 : 0,
-                    AuthorScore = int.TryParse(times.Attribute("authorscore")?.Value ?? string.Empty, out int i5) ? i5 : 0,
+                    Bronze = int.TryParse(times.Attribute("bronze")?.Value ?? string.Empty, out int i1) ? (int?)i1 : null,
+                    Silver = int.TryParse(times.Attribute("silver")?.Value ?? string.Empty, out int i2) ? (int?)i2 : null,
+                    Gold = int.TryParse(times.Attribute("gold")?.Value ?? string.Empty, out int i3) ? (int?)i3 : null,
+                    AuthorTime = int.TryParse(times.Attribute("authortime")?.Value ?? string.Empty, out int i4) ? (int?)i4 : null,
+                    AuthorScore = int.TryParse(times.Attribute("authorscore")?.Value ?? string.Empty, out int i5) ? (int?)i5 : null,
                 };
             }
 
@@ -138,7 +138,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
 
         public string Title { get; set; }
 
-        public int Lightmap { get; set; }
+        public int? Lightmap { get; set; }
     }
 
     public class MapCommunityIdentity
@@ -164,15 +164,15 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
 
         public string MapStyle { get; set; }
 
-        public bool Validated { get; set; }
+        public bool? Validated { get; set; }
 
-        public int LapCount { get; set; }
+        public int? LapCount { get; set; }
 
-        public int DisplayCost { get; set; }
+        public int? DisplayCost { get; set; }
 
         public string Mod { get; set; }
 
-        public bool HasGhostBlocks { get; set; }
+        public bool? HasGhostBlocks { get; set; }
     }
 
     public class MapCommunityPlayerModel
@@ -182,23 +182,23 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
 
     public class MapCommunityTimes
     {
-        public int Bronze { get; set; }
+        public int? Bronze { get; set; }
 
-        public TimeSpan? BronzeTimeSpan { get => this.Bronze != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.Bronze) : null; }
+        public TimeSpan? BronzeTimeSpan { get => this.Bronze != null && this.Bronze != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.Bronze.Value) : null; }
 
-        public int Silver { get; set; }
+        public int? Silver { get; set; }
 
-        public TimeSpan? SilverTimeSpan { get => this.Silver != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.Silver) : null; }
+        public TimeSpan? SilverTimeSpan { get => this.Silver != null && this.Silver != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.Silver.Value) : null; }
 
-        public int Gold { get; set; }
+        public int? Gold { get; set; }
 
-        public TimeSpan? GoldTimeSpan { get => this.Gold != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.Gold) : null; }
+        public TimeSpan? GoldTimeSpan { get => this.Gold != null && this.Gold != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.Gold.Value) : null; }
 
-        public int AuthorTime { get; set; }
+        public int? AuthorTime { get; set; }
 
-        public TimeSpan? AuthorTimeSpan { get => this.AuthorTime != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.AuthorTime) : null; }
+        public TimeSpan? AuthorTimeSpan { get => this.AuthorTime != null && this.AuthorTime != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.AuthorTime.Value) : null; }
 
-        public int AuthorScore { get; set; }
+        public int? AuthorScore { get; set; }
     }
 
     public class MapCommunityDependency

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapCommunityChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapCommunityChunk.cs
@@ -184,19 +184,19 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
     {
         public int Bronze { get; set; }
 
-        public TimeSpan BronzeTimeSpan { get => TimeSpan.FromMilliseconds(this.Bronze); }
+        public TimeSpan? BronzeTimeSpan { get => this.Bronze != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.Bronze) : null; }
 
         public int Silver { get; set; }
 
-        public TimeSpan SilverTimeSpan { get => TimeSpan.FromMilliseconds(this.Silver); }
+        public TimeSpan? SilverTimeSpan { get => this.Silver != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.Silver) : null; }
 
         public int Gold { get; set; }
 
-        public TimeSpan GoldTimeSpan { get => TimeSpan.FromMilliseconds(this.Gold); }
+        public TimeSpan? GoldTimeSpan { get => this.Gold != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.Gold) : null; }
 
         public int AuthorTime { get; set; }
 
-        public TimeSpan AuthorTimeSpan { get => TimeSpan.FromMilliseconds(this.AuthorTime); }
+        public TimeSpan? AuthorTimeSpan { get => this.AuthorTime != -1 ? (TimeSpan?)TimeSpan.FromMilliseconds(this.AuthorTime) : null; }
 
         public int AuthorScore { get; set; }
     }

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapDescriptionChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapDescriptionChunk.cs
@@ -37,22 +37,22 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
         [Property, Condition(nameof(Version), ConditionOperator.GreaterThanOrEqual, 1)]
         public uint BronzeTime { get; set; }
 
-        public TimeSpan BronzeTimeSpan { get => TimeSpan.FromMilliseconds(this.BronzeTime); }
+        public TimeSpan? BronzeTimeSpan { get => this.BronzeTime != uint.MaxValue ? (TimeSpan?)TimeSpan.FromMilliseconds(this.BronzeTime) : null; }
 
         [Property, Condition(nameof(Version), ConditionOperator.GreaterThanOrEqual, 1)]
         public uint SilverTime { get; set; }
 
-        public TimeSpan SilverTimeSpan { get => TimeSpan.FromMilliseconds(this.SilverTime); }
+        public TimeSpan? SilverTimeSpan { get => this.SilverTime != uint.MaxValue ? (TimeSpan?)TimeSpan.FromMilliseconds(this.SilverTime) : null; }
 
         [Property, Condition(nameof(Version), ConditionOperator.GreaterThanOrEqual, 1)]
         public uint GoldTime { get; set; }
 
-        public TimeSpan GoldTimeSpan { get => TimeSpan.FromMilliseconds(this.GoldTime); }
+        public TimeSpan? GoldTimeSpan { get => this.GoldTime != uint.MaxValue ? (TimeSpan?)TimeSpan.FromMilliseconds(this.GoldTime) : null; }
 
         [Property, Condition(nameof(Version), ConditionOperator.GreaterThanOrEqual, 1)]
         public uint AuthorTime { get; set; }
 
-        public TimeSpan AuthorTimeSpan { get => TimeSpan.FromMilliseconds(this.AuthorTime); }
+        public TimeSpan? AuthorTimeSpan { get => this.AuthorTime != uint.MaxValue ? (TimeSpan?)TimeSpan.FromMilliseconds(this.AuthorTime) : null; }
 
         [Property, Condition(nameof(Version), ConditionOperator.Equal, 2)]
         public byte Unknown2 { get; set; }

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapTimelimitChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapTimelimitChunk.cs
@@ -12,12 +12,12 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
         [Obsolete("Raw Value, use GbxTimeLimitClass.TimeLimit instead", false)]
         public uint TimeLimitU { get; set; }
 
-        public TimeSpan TimeLimit { get => TimeSpan.FromMilliseconds(this.TimeLimitU); }
+        public TimeSpan? TimeLimit { get => this.TimeLimitU != uint.MaxValue ? (TimeSpan?)TimeSpan.FromMilliseconds(this.TimeLimitU) : null; }
 
         [Property]
         [Obsolete("Raw Value, use MapTimelimitChunk.AuthorTime instead", false)]
         public uint AuthorTimeU { get; set; }
 
-        public TimeSpan AuthorTime { get => TimeSpan.FromMilliseconds(this.AuthorTimeU); }
+        public TimeSpan? AuthorTime { get => this.AuthorTimeU != uint.MaxValue ? (TimeSpan?)TimeSpan.FromMilliseconds(this.AuthorTimeU) : null; }
     }
 }


### PR DESCRIPTION
Currently, time spans representing empty times are set to the found value (either -1 or int.maxvalue/uint.maxvalue) instead of something properly representing the fact that this value is not available from the file. This PR fixes that behaviour, but might break previous depending software.