### PR TITLE
Add support for TMUnlimiter challenge chunks

### DIFF
--- a/src/ManiaPlanetSharp/GameBox/MetadataProviders/MapMetadataProvider.cs
+++ b/src/ManiaPlanetSharp/GameBox/MetadataProviders/MapMetadataProvider.cs
@@ -1,5 +1,7 @@
 ﻿using ManiaPlanetSharp.GameBox.Parsing.Chunks;
+using ManiaPlanetSharp.GameBox.Parsing.Chunks.TMUnlimiter;
 using ManiaPlanetSharp.GameBox.Parsing.Utils;
+using ManiaPlanetSharp.TMUnlimiter;
 using ManiaPlanetSharp.Utilities;
 using System;
 using System.Collections.Generic;
@@ -210,7 +212,15 @@ namespace ManiaPlanetSharp.GameBox.MetadataProviders
 
         public virtual ulong? LightmapCacheUid => this.GetBufferedHeaderValue((MapCommonChunk c) => c?.LightmapCacheUid);
 
+        public virtual ChallengeBackend ChallengeBackend => this.GetBufferedBodyValue((ChallengeBackendChunkGen5 c) => c.ChallengeBackend)
+            .IfNull((ChallengeBackendChunkGen4 c) => c.ChallengeBackend)
+            .IfNull((ChallengeBackendChunkGen3 c) => c.ChallengeBackend)
+            .IfNull((ChallengeBackendChunkGen2 c) => c.ChallengeBackend)
+            .IfNull((ChallengeBackendChunkGen1 c) => c.ChallengeBackend);
 
+        public virtual ParameterSet[] LegacyParameterSets => this.GetBodyNodes<LegacyParameterSetChunk>()?.Where(chunk => chunk?.ParameterSet != null)?.Select(chunk => chunk?.ParameterSet)?.ToArray();
+
+        public virtual LegacyScript[] LegacyScripts => this.GetBodyNodes<LegacyScriptChunk>()?.Where(chunk => chunk?.LegacyScript != null)?.Select(chunk => chunk?.LegacyScript)?.ToArray();
 
         public EmbeddedItemFile[] GetEmbeddedItemFiles()
         {

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/TMUnlimiter/ChallengeBackendChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/TMUnlimiter/ChallengeBackendChunk.cs
@@ -1,0 +1,204 @@
+using System;
+using System.IO;
+using ManiaPlanetSharp.TMUnlimiter;
+using VersionBackendUnlimiter13 = ManiaPlanetSharp.TMUnlimiter.Version13.VersionBackend;
+
+namespace ManiaPlanetSharp.GameBox.Parsing.Chunks.TMUnlimiter
+{
+    public abstract class ChallengeBackendChunk : Chunk
+    {
+        [Property, CustomParserMethod(nameof(Archive))]
+        public ChallengeBackend ChallengeBackend { get; set; }
+
+#pragma warning disable CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+        public ChallengeBackend Archive(GameBoxReader reader)
+        {
+            uint archivingChunkId = this.GetArchivingChunkId();
+
+            switch ( archivingChunkId )
+            {
+                // TMUnlimiter 1.1 and 1.2 chunk
+                case 0x03_043_055u:
+                {
+                    byte chunkVersion = reader.ReadByte();
+
+                    switch ( chunkVersion )
+                    {
+                        // Version 0 from TMUnlimiter 1.1
+                        case 1:
+                        {
+                            ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter11 );
+                            break;
+                        }
+                        // Version 1 from TMUnlimiter 1.2
+                        case 2:
+                        {
+                            ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter12 );
+                            break;
+                        }
+                        default:
+                        {
+                            throw new NotSupportedException( $"Unknown version of chunk 0x03043055 (version = {chunkVersion}). This chunk only supports versions 1 and 2." );
+                        }
+                    }
+
+                    ChallengeBackend.ArchiveOld( reader );
+                    break;
+                }
+                // TMUnlimiter 1.3 chunk (skippable)
+                case 0x3f_001_000u:
+                {
+                    ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter13 );
+
+                    reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
+                    // Chunk size is an unsigned integer, but MemoryStream works on integers instead...
+                    int chunkSize = reader.ReadInt32();
+
+                    // Decrypt weakly encrypted TMUnlimiter 1.3 chunk
+                    byte[] cryptedChunkData = VersionBackendUnlimiter13.DecryptChunkData( reader.ReadRaw( chunkSize ) );
+
+                    // Parse TMUnlimiter 1.3 chunk properly. A separate GameBoxReader instance is used because
+                    // there is no method to initialize a nested GameBoxReader instance from a byte array.
+                    // Anyway, this does not affect parsing in any way, as legacy TMUnlimiter chunks did
+                    // not rely on any MwId strings, internal or external references.
+                    using ( GameBoxReader innerReader = new GameBoxReader( new MemoryStream( cryptedChunkData ) ) )
+                    {
+                        ChallengeBackend.ArchiveOld( innerReader );
+                    }
+
+                    break;
+                }
+                // TMUnlimiter 2.0 chunks (skippable)
+                case 0x3f_001_001u:
+                case 0x3f_001_002u:
+                case 0x3f_001_003u:
+                {
+                    reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
+                    // Chunk size is an unsigned integer, but MemoryStream works on integers instead...
+                    int chunkSize = reader.ReadInt32();
+
+                    using ( GameBoxReader innerReader = reader.GetNestedLengthLimitedReader( chunkSize ) )
+                    {
+                        uint archiveVersion = archivingChunkId - 0x3f_001_001;
+                        byte primaryTrackVersion = innerReader.ReadByte();
+
+                        switch ( primaryTrackVersion )
+                        {
+                            // Vanilla track version
+                            case 0:
+                            {
+                                ChallengeBackend = new ChallengeBackend( TrackVersion.Vanilla );
+                                break;
+                            }
+                            // TMUnlimiter 0.4 track version
+                            case 1:
+                            {
+                                ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter04 );
+                                break;
+                            }
+                            // TMUnlimiter 0.6 track version
+                            case 2:
+                            {
+                                ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter06 );
+                                break;
+                            }
+                            // TMUnlimiter 0.7 track version
+                            case 3:
+                            {
+                                ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter07 );
+                                break;
+                            }
+                            // TMUnlimiter 1.1 track version
+                            case 4:
+                            {
+                                ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter11 );
+                                break;
+                            }
+                            // TMUnlimiter 1.2 track version
+                            case 5:
+                            {
+                                ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter12 );
+                                break;
+                            }
+                            // TMUnlimiter 1.3 track version
+                            case 6:
+                            {
+                                ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter13 );
+                                break;
+                            }
+                            // TMUnlimiter 2.0 track version
+                            case 7:
+                            {
+                                ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter20 );
+                                break;
+                            }
+                            default:
+                            {
+                                throw new NotSupportedException( $"Unsupported track version = { primaryTrackVersion }" );
+                            }
+                        }
+
+                        ChallengeBackend.ArchiveNew( innerReader, archiveVersion );
+                    }
+
+                    break;
+                }
+                // Unknown chunk
+                default:
+                {
+                    throw new NotSupportedException( $"Unknown chunk \"0x{archivingChunkId:X8}\"" );
+                }
+            }
+
+            return ChallengeBackend;
+        }
+#pragma warning restore CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+
+        protected abstract uint GetArchivingChunkId();
+    }
+
+    [Chunk(0x03_043_055u, skippable: false)]
+    public class ChallengeBackendChunkGen1 : ChallengeBackendChunk
+    {
+        protected override uint GetArchivingChunkId()
+        {
+            return 0x03_043_055u;
+        }
+    }
+
+    [Chunk(0x3f_001_000u, skippable: true)]
+    public class ChallengeBackendChunkGen2 : ChallengeBackendChunk
+    {
+        protected override uint GetArchivingChunkId()
+        {
+            return 0x3f_001_000u;
+        }
+    }
+
+    [Chunk(0x3f_001_001u, skippable: true)]
+    public class ChallengeBackendChunkGen3 : ChallengeBackendChunk
+    {
+        protected override uint GetArchivingChunkId()
+        {
+            return 0x3f_001_001u;
+        }
+    }
+
+    [Chunk(0x3f_001_002u, skippable: true)]
+    public class ChallengeBackendChunkGen4 : ChallengeBackendChunk
+    {
+        protected override uint GetArchivingChunkId()
+        {
+            return 0x3f_001_002u;
+        }
+    }
+
+    [Chunk(0x3f_001_003u, skippable: true)]
+    public class ChallengeBackendChunkGen5 : ChallengeBackendChunk
+    {
+        protected override uint GetArchivingChunkId()
+        {
+            return 0x3f_001_003u;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/TMUnlimiter/LegacyParameterSetChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/TMUnlimiter/LegacyParameterSetChunk.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using ManiaPlanetSharp.TMUnlimiter;
+using VersionBackendUnlimiter13 = ManiaPlanetSharp.TMUnlimiter.Version13.VersionBackend;
+
+namespace ManiaPlanetSharp.GameBox.Parsing.Chunks.TMUnlimiter
+{
+    [Chunk(0x3f_003_00fu, skippable: true)]
+    public class LegacyParameterSetChunk : Chunk
+    {
+        [Property, CustomParserMethod(nameof(Archive))]
+        public ParameterSet ParameterSet { get; set; }
+
+#pragma warning disable CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+        public ParameterSet Archive( GameBoxReader reader )
+        {
+            reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
+            // Chunk size is an unsigned integer, but MemoryStream works on integers instead...
+            int chunkSize = reader.ReadInt32();
+
+            // Decrypt weakly encrypted TMUnlimiter 1.3 chunk
+            byte[] cryptedChunkData = VersionBackendUnlimiter13.DecryptChunkData( reader.ReadRaw( chunkSize ) );
+
+            using ( GameBoxReader innerReader = new GameBoxReader( new MemoryStream( cryptedChunkData ) ) )
+            {
+                ParameterSet parameterSet = new ParameterSet();
+                uint parameterCount = innerReader.ReadUInt32();
+
+                for ( uint parameterIndex = 0; parameterIndex < parameterCount; parameterIndex++ )
+                {
+                    ParameterFunction parameterFunction = VersionBackendUnlimiter13.GetParameterFunction( innerReader.ReadByte(), innerReader.ReadByte() );
+
+                    if ( parameterFunction == null )
+                    {
+                        continue;
+                    }
+
+                    switch ( parameterFunction.ValueType )
+                    {
+                        case ParameterValueType.Number:
+                        {
+                            parameterSet.Parameters.Add( new ParameterNumber( parameterFunction, innerReader.ReadFloat() ) );
+                            break;
+                        }
+                        case ParameterValueType.String:
+                        {
+                            parameterSet.Parameters.Add( new ParameterString( parameterFunction, innerReader.ReadString( innerReader.ReadByte() ) ) );
+                            break;
+                        }
+                        default:
+                        {
+                            parameterSet.Parameters.Add( new Parameter( parameterFunction ) );
+                            break;
+                        }
+                    }
+                }
+
+                return parameterSet.Parameters.Count > 0 ? parameterSet : null;
+            }
+        }
+#pragma warning restore CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+    }
+}

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/TMUnlimiter/LegacyScriptChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/TMUnlimiter/LegacyScriptChunk.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using ManiaPlanetSharp.TMUnlimiter;
+using VersionBackendUnlimiter13 = ManiaPlanetSharp.TMUnlimiter.Version13.VersionBackend;
+
+namespace ManiaPlanetSharp.GameBox.Parsing.Chunks.TMUnlimiter
+{
+    [Chunk(0x3f_004_00fu, skippable: true)]
+    public class LegacyScriptChunk : Chunk
+    {
+        [Property, CustomParserMethod(nameof(Archive))]
+        public LegacyScript LegacyScript { get; set; }
+
+#pragma warning disable CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+        public LegacyScript Archive( GameBoxReader reader )
+        {
+            reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
+            // Chunk size is an unsigned integer, but MemoryStream works on integers instead...
+            int chunkSize = reader.ReadInt32();
+
+            // Decrypt weakly encrypted TMUnlimiter 1.3 chunk
+            byte[] cryptedChunkData = VersionBackendUnlimiter13.DecryptChunkData( reader.ReadRaw( chunkSize ) );
+
+            using ( GameBoxReader innerReader = new GameBoxReader( new MemoryStream( cryptedChunkData ) ) )
+            {
+                LegacyScriptExecutionType executionType;
+
+                // Match legacy script execution type
+                switch ( innerReader.ReadByte() )
+                {
+                    case 1:
+                    {
+                        executionType = LegacyScriptExecutionType.TriggerAlways;
+                        break;
+                    }
+                    case 2:
+                    {
+                        executionType = LegacyScriptExecutionType.TriggerInside;
+                        break;
+                    }
+                    default:
+                    {
+                        executionType = LegacyScriptExecutionType.TriggerOnce;
+                        break;
+                    }
+                }
+
+                // Chunk size is an unsigned integer, but MemoryStream works on integers instead...
+                return new LegacyScript( innerReader.ReadRaw( innerReader.ReadInt32() ), executionType );
+            }
+        }
+#pragma warning restore CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/BlockData.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/BlockData.cs
@@ -1,0 +1,96 @@
+using ManiaPlanetSharp.GameBox;
+
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public abstract class BlockData
+    {
+        public uint BlockIndex { get; private set; }
+
+        public BlockData( uint blockIndex )
+        {
+            this.BlockIndex = blockIndex;
+        }
+
+        public abstract TrackVersion GetTrackVersion();
+
+        public virtual uint GetOverOverSizeChunkX()
+        {
+            return 0;
+        }
+
+        public virtual uint GetOverOverSizeChunkY()
+        {
+            return 0;
+        }
+
+        public virtual uint GetOverOverSizeChunkZ()
+        {
+            return 0;
+        }
+
+        public virtual bool IsClassicTerrain()
+        {
+            return false;
+        }
+
+        public virtual bool IsInverted()
+        {
+            return false;
+        }
+
+        public virtual bool IsOffsetApplied()
+        {
+            return false;
+        }
+
+        public virtual bool IsRotationApplied()
+        {
+            return false;
+        }
+
+        public virtual bool IsScaleApplied()
+        {
+            return false;
+        }
+
+        public virtual Vector3D GetOffset()
+        {
+            return new Vector3D();
+        }
+
+        public virtual Vector3D GetRotation()
+        {
+            return new Vector3D();
+        }
+
+        public virtual Vector3D GetScale()
+        {
+            return new Vector3D( 1.0f, 1.0f, 1.0f );
+        }
+
+        public virtual SpawnPointAlterMethod GetSpawnPointAlterMethod()
+        {
+            return SpawnPointAlterMethod.None;
+        }
+
+        public virtual bool IsDynamic()
+        {
+            return false;
+        }
+
+        public virtual bool IsInvisible()
+        {
+            return false;
+        }
+
+        public virtual bool IsCollisionDisabled()
+        {
+            return false;
+        }
+
+        public virtual bool IsInBlockGroup( string blockGroup )
+        {
+            return false;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/ChallengeBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/ChallengeBackend.cs
@@ -1,0 +1,79 @@
+using ManiaPlanetSharp.GameBox.Parsing;
+using System;
+
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public class ChallengeBackend
+    {
+        public VersionBackend VersionBackend { get; set; }
+        public bool IsLegacyFormat { get; set; }
+
+        public ChallengeBackend( TrackVersion trackVersion )
+        {
+            switch ( trackVersion )
+            {
+                case TrackVersion.Vanilla:
+                {
+                    this.VersionBackend = new Vanilla.VersionBackend();
+                    break;
+                }
+                case TrackVersion.Unlimiter04:
+                {
+                    this.VersionBackend = new Version04.VersionBackend();
+                    break;
+                }
+                case TrackVersion.Unlimiter06:
+                {
+                    this.VersionBackend = new Version06.VersionBackend();
+                    break;
+                }
+                case TrackVersion.Unlimiter07:
+                {
+                    this.VersionBackend = new Version07.VersionBackend();
+                    break;
+                }
+                case TrackVersion.Unlimiter11:
+                {
+                    this.VersionBackend = new Version11.VersionBackend();
+                    break;
+                }
+                case TrackVersion.Unlimiter12:
+                {
+                    this.VersionBackend = new Version12.VersionBackend();
+                    break;
+                }
+                case TrackVersion.Unlimiter13:
+                {
+                    this.VersionBackend = new Version13.VersionBackend();
+                    break;
+                }
+                case TrackVersion.Unlimiter20:
+                {
+                    this.VersionBackend = new Version20.VersionBackend();
+                    break;
+                }
+                default:
+                {
+                    throw new NotSupportedException( $"Unsupported track version = { trackVersion }" );
+                }
+            }
+        }
+
+        public TrackVersion GetTrackVersion()
+        {
+            return this.VersionBackend.GetTrackVersion();
+        }
+
+        public void ArchiveOld( GameBoxReader reader )
+        {
+            this.IsLegacyFormat = true;
+            this.VersionBackend.ArchiveOld( reader );
+        }
+
+        public void ArchiveNew( GameBoxReader reader, uint archiveVersion )
+        {
+            this.IsLegacyFormat = false;
+            this.VersionBackend.ArchiveNew( reader, archiveVersion );
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/DecorationVisibility.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/DecorationVisibility.cs
@@ -1,0 +1,10 @@
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public enum DecorationVisibility
+    {
+        Default,
+        SkyOnly,
+        WarpOnly,
+        Nothing,
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/LegacyMediaClipResource.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/LegacyMediaClipResource.cs
@@ -1,0 +1,38 @@
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public class LegacyMediaClipResource
+    {
+        public uint MediaClipIndex { get; private set; }
+        public object Resource { get; private set; }
+
+        public LegacyMediaClipResource( uint mediaClipIndex, object resource )
+        {
+            this.MediaClipIndex = mediaClipIndex;
+            this.Resource = resource;
+        }
+
+        public ParameterSet GetParameterSet()
+        {
+            return
+            (
+                this.Resource != null && this.Resource is ParameterSet parameterSet
+                ?
+                parameterSet
+                :
+                null
+            );
+        }
+
+        public LegacyScript GetLegacyScript()
+        {
+            return
+            (
+                this.Resource != null && this.Resource is LegacyScript legacyScript
+                ?
+                legacyScript
+                :
+                null
+            );
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/LegacyScript.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/LegacyScript.cs
@@ -1,0 +1,14 @@
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public class LegacyScript
+    {
+        public readonly byte[] ByteCode;
+        public readonly LegacyScriptExecutionType ExecutionType;
+
+        public LegacyScript( byte[] byteCode, LegacyScriptExecutionType executionType )
+        {
+            this.ByteCode = byteCode;
+            this.ExecutionType = executionType;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/LegacyScriptExecutionType.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/LegacyScriptExecutionType.cs
@@ -1,0 +1,9 @@
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public enum LegacyScriptExecutionType
+    {
+        TriggerOnce,
+        TriggerInside,
+        TriggerAlways,
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Parameter.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Parameter.cs
@@ -1,0 +1,32 @@
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public class Parameter
+    {
+        public ParameterFunction ParameterFunction { get; private set; }
+
+        public Parameter( ParameterFunction parameterFunction )
+        {
+            this.ParameterFunction = parameterFunction;
+        }
+    }
+
+    public class ParameterNumber : Parameter
+    {
+        public float Value { get; private set; }
+
+        public ParameterNumber( ParameterFunction parameterFunction, float value ) : base( parameterFunction )
+        {
+            this.Value = value;
+        }
+    }
+
+    public class ParameterString : Parameter
+    {
+        public string Value { get; private set; }
+
+        public ParameterString( ParameterFunction parameterFunction, string value ) : base( parameterFunction )
+        {
+            this.Value = value;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/ParameterFunction.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/ParameterFunction.cs
@@ -1,0 +1,14 @@
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public class ParameterFunction
+    {
+        public string Name { get; private set; }
+        public ParameterValueType ValueType { get; private set; }
+
+        public ParameterFunction( string name, ParameterValueType valueType )
+        {
+            this.Name = name;
+            this.ValueType = valueType;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/ParameterSet.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/ParameterSet.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public class ParameterSet
+    {
+        public List<Parameter> Parameters = new List<Parameter>();
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/ParameterValueType.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/ParameterValueType.cs
@@ -1,0 +1,9 @@
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public enum ParameterValueType
+    {
+        None,
+        Number,
+        String,
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/SpawnPointAlterMethod.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/SpawnPointAlterMethod.cs
@@ -1,0 +1,9 @@
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public enum SpawnPointAlterMethod
+    {
+        None,
+        Manual,
+        Automatic,
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/TrackVersion.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/TrackVersion.cs
@@ -1,0 +1,14 @@
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public enum TrackVersion
+    {
+        Vanilla = 0,
+        Unlimiter04 = 1,
+        Unlimiter06 = 2,
+        Unlimiter07 = 3,
+        Unlimiter11 = 4,
+        Unlimiter12 = 5,
+        Unlimiter13 = 6,
+        Unlimiter20 = 7,
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Vanilla/VersionBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Vanilla/VersionBackend.cs
@@ -1,0 +1,17 @@
+using ManiaPlanetSharp.GameBox.Parsing;
+
+namespace ManiaPlanetSharp.TMUnlimiter.Vanilla
+{
+    public class VersionBackend : TMUnlimiter.VersionBackend
+    {
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Vanilla;
+        }
+
+        public override void ArchiveNew( GameBoxReader reader, uint archiveVersion )
+        {
+            // Vanilla track version does not save anything.
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version04/VersionBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version04/VersionBackend.cs
@@ -1,0 +1,10 @@
+namespace ManiaPlanetSharp.TMUnlimiter.Version04
+{
+    public class VersionBackend : TMUnlimiter.VersionBackend
+    {
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter04;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version06/BlockData.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version06/BlockData.cs
@@ -1,0 +1,37 @@
+namespace ManiaPlanetSharp.TMUnlimiter.Version06
+{
+    public class BlockData : TMUnlimiter.BlockData
+    {
+        public uint InternalOverOverSizeChunkX { get; set; }
+        public uint InternalOverOverSizeChunkY { get; set; }
+        public uint InternalOverOverSizeChunkZ { get; set; }
+        public bool InternalIsClassicTerrain { get; set; }
+
+        public BlockData( uint blockIndex ) : base( blockIndex ) {}
+
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter06;
+        }
+
+        public override uint GetOverOverSizeChunkX()
+        {
+            return this.InternalOverOverSizeChunkX;
+        }
+
+        public override uint GetOverOverSizeChunkY()
+        {
+            return this.InternalOverOverSizeChunkY;
+        }
+
+        public override uint GetOverOverSizeChunkZ()
+        {
+            return this.InternalOverOverSizeChunkZ;
+        }
+
+        public override bool IsClassicTerrain()
+        {
+            return this.InternalIsClassicTerrain;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version06/VersionBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version06/VersionBackend.cs
@@ -1,0 +1,10 @@
+namespace ManiaPlanetSharp.TMUnlimiter.Version06
+{
+    public class VersionBackend : TMUnlimiter.VersionBackend
+    {
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter06;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version07/BlockData.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version07/BlockData.cs
@@ -1,0 +1,43 @@
+namespace ManiaPlanetSharp.TMUnlimiter.Version07
+{
+    public class BlockData : TMUnlimiter.BlockData
+    {
+        public uint InternalOverOverSizeChunkX { get; set; }
+        public uint InternalOverOverSizeChunkY { get; set; }
+        public uint InternalOverOverSizeChunkZ { get; set; }
+        public bool InternalIsClassicTerrain { get; set; }
+        public bool InternalIsInverted { get; set; }
+
+        public BlockData( uint blockIndex ) : base( blockIndex ) {}
+
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter07;
+        }
+
+        public override uint GetOverOverSizeChunkX()
+        {
+            return this.InternalOverOverSizeChunkX;
+        }
+
+        public override uint GetOverOverSizeChunkY()
+        {
+            return this.InternalOverOverSizeChunkY;
+        }
+
+        public override uint GetOverOverSizeChunkZ()
+        {
+            return this.InternalOverOverSizeChunkZ;
+        }
+
+        public override bool IsClassicTerrain()
+        {
+            return this.InternalIsClassicTerrain;
+        }
+
+        public override bool IsInverted()
+        {
+            return this.InternalIsInverted;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version07/VersionBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version07/VersionBackend.cs
@@ -1,0 +1,10 @@
+namespace ManiaPlanetSharp.TMUnlimiter.Version07
+{
+    public class VersionBackend : TMUnlimiter.VersionBackend
+    {
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter07;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version11/BlockData.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version11/BlockData.cs
@@ -1,0 +1,71 @@
+using ManiaPlanetSharp.GameBox;
+
+namespace ManiaPlanetSharp.TMUnlimiter.Version11
+{
+    public class BlockData : TMUnlimiter.BlockData
+    {
+        public uint InternalOverOverSizeChunkX { get; set; }
+        public uint InternalOverOverSizeChunkY { get; set; }
+        public uint InternalOverOverSizeChunkZ { get; set; }
+        public bool InternalIsClassicTerrain { get; set; }
+        public bool InternalIsInverted { get; set; }
+        public int InternalBlockOffsetX { get; set; }
+        public int InternalBlockOffsetY { get; set; }
+        public int InternalBlockOffsetZ { get; set; }
+        public uint InternalBlockRotationX { get; set; }
+        public uint InternalBlockRotationY { get; set; }
+        public uint InternalBlockRotationZ { get; set; }
+
+        public BlockData( uint blockIndex ) : base( blockIndex ) {}
+
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter11;
+        }
+
+        public override uint GetOverOverSizeChunkX()
+        {
+            return this.InternalOverOverSizeChunkX;
+        }
+
+        public override uint GetOverOverSizeChunkY()
+        {
+            return this.InternalOverOverSizeChunkY;
+        }
+
+        public override uint GetOverOverSizeChunkZ()
+        {
+            return this.InternalOverOverSizeChunkZ;
+        }
+
+        public override bool IsClassicTerrain()
+        {
+            return this.InternalIsClassicTerrain;
+        }
+
+        public override bool IsInverted()
+        {
+            return this.InternalIsInverted;
+        }
+
+        public override bool IsOffsetApplied()
+        {
+            return this.InternalBlockOffsetX != 0 || this.InternalBlockOffsetY != 0 || this.InternalBlockOffsetZ != 0;
+        }
+
+        public override bool IsRotationApplied()
+        {
+            return this.InternalBlockRotationX != 0 || this.InternalBlockRotationY != 0 || this.InternalBlockRotationZ != 0;
+        }
+
+        public override Vector3D GetOffset()
+        {
+            return new Vector3D( this.InternalBlockOffsetX, this.InternalBlockOffsetY, this.InternalBlockOffsetZ );
+        }
+
+        public override Vector3D GetRotation()
+        {
+            return new Vector3D( this.InternalBlockRotationX * 5, this.InternalBlockRotationY * 5, this.InternalBlockRotationZ * 5 );
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version11/VersionBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version11/VersionBackend.cs
@@ -1,0 +1,217 @@
+using System.Collections.Generic;
+using ManiaPlanetSharp.GameBox;
+using ManiaPlanetSharp.GameBox.Parsing;
+
+namespace ManiaPlanetSharp.TMUnlimiter.Version11
+{
+    public class VersionBackend : TMUnlimiter.VersionBackend
+    {
+        public static readonly List<ParameterFunction> VehicleParameterFunctions = new List<ParameterFunction>();
+        public static readonly List<ParameterFunction> ResetParameterFunctions = new List<ParameterFunction>();
+        public static readonly List<ParameterFunction> ClipCommunicationParameterFunctions = new List<ParameterFunction>();
+
+        static VersionBackend()
+        {
+            VehicleParameterFunctions.Add( null ); // "None" function
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle gravity (new method)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle gravity (old method)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle gravity (simple invert)", ParameterValueType.None ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle max speed (forward)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle max speed (backward)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change yellow booster multipiler", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change red booster multipiler", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change acceleration multipiler", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change acceleration multipiler (new)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change yellow booster effect time", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change red booster effect time", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( null ); // "Change vehicle property (Locked)" function
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change drift deceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change air deceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change steering strength", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change steepness acceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change roof deceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle grip", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change free wheeling brake", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle brake", ParameterValueType.Number ) );
+
+            ResetParameterFunctions.Add( null ); // "None" function
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset all vehicle values to default", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle gravity", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle max speed", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle max speed (forward)", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle max speed (backward)", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset booster multipiler value", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset yellow booster multipiler value", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset red booster multipiler value", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset acceleration multipiler", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset booster effect time", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset yellow booster effect time", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset red booster effect time", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset drift deceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset air deceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset steering strength", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset steepness acceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset roof deceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle grip", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset free wheeling brake", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle brake", ParameterValueType.None ) );
+
+            ClipCommunicationParameterFunctions.Add( null ); // "None" function
+            ClipCommunicationParameterFunctions.Add( new ParameterFunction( "Clip Communication/Communicate with another clip", ParameterValueType.Number ) );
+            ClipCommunicationParameterFunctions.Add( new ParameterFunction( "Clip Communication/Communicate with another clip and display", ParameterValueType.Number ) );
+            ClipCommunicationParameterFunctions.Add( new ParameterFunction( "Clip Communication/Add script to update list", ParameterValueType.Number ) );
+        }
+
+        public static ParameterFunction GetParameterFunction( uint catalogIndex, uint functionIndex )
+        {
+            switch ( catalogIndex )
+            {
+                case 1: // "Vehicle"
+                {
+                    return
+                    (
+                        functionIndex >= VehicleParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        VehicleParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                case 2: // "Reset" catalog
+                {
+                    return
+                    (
+                        functionIndex >= ResetParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        ResetParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                case 3: // "Clip Communication" catalog
+                {
+                    return
+                    (
+                        functionIndex >= ClipCommunicationParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        ClipCommunicationParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                default: // Unknown catalog
+                {
+                    return null;
+                }
+            }
+        }
+
+        protected new class Chunk03043055 : TMUnlimiter.VersionBackend.Chunk03043055
+        {
+            VersionBackend VersionBackend { get; set; }
+
+            public Chunk03043055( VersionBackend versionBackend )
+            {
+                this.VersionBackend = versionBackend;
+            }
+
+#pragma warning disable CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+            protected override void ArchiveBlock( GameBoxReader reader, uint blockIndex )
+            {
+                BlockData blockData = new BlockData( blockIndex );
+
+                blockData.InternalOverOverSizeChunkX = reader.ReadByte();
+                blockData.InternalOverOverSizeChunkY = reader.ReadByte();
+                blockData.InternalOverOverSizeChunkZ = reader.ReadByte();
+                blockData.InternalIsInverted = reader.ReadByte() != 0;
+                blockData.InternalBlockOffsetX = reader.ReadInt32();
+                blockData.InternalBlockOffsetY = reader.ReadInt32();
+                blockData.InternalBlockOffsetZ = reader.ReadInt32();
+                blockData.InternalBlockRotationX = reader.ReadByte();
+                blockData.InternalBlockRotationY = reader.ReadByte();
+                blockData.InternalBlockRotationZ = reader.ReadByte();
+
+                this.VersionBackend.BlocksData.Add( blockData );
+            }
+#pragma warning restore CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+
+            protected override void SetDecorationOffset( int offsetX, int offsetY, int offsetZ )
+            {
+                this.VersionBackend.DecorationOffsetX = offsetX;
+                this.VersionBackend.DecorationOffsetY = offsetY;
+                this.VersionBackend.DecorationOffsetZ = offsetZ;
+            }
+
+            protected override void SetSkyOnlyDecorationVisibility( bool skyOnlyDecorationVisibility )
+            {
+                this.VersionBackend.DecorationVisibility_SkyOnly = skyOnlyDecorationVisibility;
+            }
+
+            protected override ParameterFunction GetParameterFunction( uint catalogIndex, uint functionIndex )
+            {
+                return VersionBackend.GetParameterFunction( catalogIndex, functionIndex );
+            }
+
+            protected override void AddLegacyMediaClipMapping( uint mediaClipIndex, object resource )
+            {
+                this.VersionBackend.LegacyMediaClipResources.Add( new LegacyMediaClipResource( mediaClipIndex, resource ) );
+            }
+        }
+
+        bool DecorationVisibility_SkyOnly;
+        int DecorationOffsetX;
+        int DecorationOffsetY;
+        int DecorationOffsetZ;
+        readonly List<BlockData> BlocksData = new List<BlockData>();
+        readonly List<LegacyMediaClipResource> LegacyMediaClipResources = new List<LegacyMediaClipResource>();
+
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter11;
+        }
+
+#pragma warning disable CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+        public override void ArchiveOld( GameBoxReader reader )
+        {
+            new Chunk03043055( this ).Archive( reader );
+        }
+
+        public override void ArchiveNew( GameBoxReader reader, uint archiveVersion )
+        {
+            // No need to implement this chunk (at the moment)
+        }
+#pragma warning restore CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+
+        public override TMUnlimiter.BlockData[] GetBlocksData()
+        {
+            return this.BlocksData.ToArray();
+        }
+
+        public override bool IsDecorationOffsetApplied()
+        {
+            return this.DecorationOffsetX != 0 || this.DecorationOffsetY != 0 || this.DecorationOffsetZ != 0;
+        }
+
+        public override Vector3D GetDecorationOffset()
+        {
+            return new Vector3D( this.DecorationOffsetX, this.DecorationOffsetY, this.DecorationOffsetZ );
+        }
+
+        public override DecorationVisibility GetDecorationVisibility()
+        {
+            if ( this.DecorationVisibility_SkyOnly )
+            {
+                return DecorationVisibility.SkyOnly;
+            }
+            else
+            {
+                return DecorationVisibility.Default;
+            }
+        }
+
+        public override LegacyMediaClipResource[] GetLegacyMediaClipResources()
+        {
+            return this.LegacyMediaClipResources.ToArray();
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version12/BlockData.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version12/BlockData.cs
@@ -1,0 +1,71 @@
+using ManiaPlanetSharp.GameBox;
+
+namespace ManiaPlanetSharp.TMUnlimiter.Version12
+{
+    public class BlockData : TMUnlimiter.BlockData
+    {
+        public uint InternalOverOverSizeChunkX { get; set; }
+        public uint InternalOverOverSizeChunkY { get; set; }
+        public uint InternalOverOverSizeChunkZ { get; set; }
+        public bool InternalIsClassicTerrain { get; set; }
+        public bool InternalIsInverted { get; set; }
+        public int InternalBlockOffsetX { get; set; }
+        public int InternalBlockOffsetY { get; set; }
+        public int InternalBlockOffsetZ { get; set; }
+        public uint InternalBlockRotationX { get; set; }
+        public uint InternalBlockRotationY { get; set; }
+        public uint InternalBlockRotationZ { get; set; }
+
+        public BlockData( uint blockIndex ) : base( blockIndex ) {}
+
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter12;
+        }
+
+        public override uint GetOverOverSizeChunkX()
+        {
+            return this.InternalOverOverSizeChunkX;
+        }
+
+        public override uint GetOverOverSizeChunkY()
+        {
+            return this.InternalOverOverSizeChunkY;
+        }
+
+        public override uint GetOverOverSizeChunkZ()
+        {
+            return this.InternalOverOverSizeChunkZ;
+        }
+
+        public override bool IsClassicTerrain()
+        {
+            return this.InternalIsClassicTerrain;
+        }
+
+        public override bool IsInverted()
+        {
+            return this.InternalIsInverted;
+        }
+
+        public override bool IsOffsetApplied()
+        {
+            return this.InternalBlockOffsetX != 0 || this.InternalBlockOffsetY != 0 || this.InternalBlockOffsetZ != 0;
+        }
+
+        public override bool IsRotationApplied()
+        {
+            return this.InternalBlockRotationX != 0 || this.InternalBlockRotationY != 0 || this.InternalBlockRotationZ != 0;
+        }
+
+        public override Vector3D GetOffset()
+        {
+            return new Vector3D( this.InternalBlockOffsetX * 0.1f, this.InternalBlockOffsetY * 0.1f, this.InternalBlockOffsetZ * 0.1f );
+        }
+
+        public override Vector3D GetRotation()
+        {
+            return new Vector3D( this.InternalBlockRotationX * 0.1f, this.InternalBlockRotationY * 0.1f, this.InternalBlockRotationZ * 0.1f );
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version12/VersionBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version12/VersionBackend.cs
@@ -1,0 +1,222 @@
+using System.Collections.Generic;
+using ManiaPlanetSharp.GameBox;
+using ManiaPlanetSharp.GameBox.Parsing;
+
+namespace ManiaPlanetSharp.TMUnlimiter.Version12
+{
+    public class VersionBackend : TMUnlimiter.VersionBackend
+    {
+        public static readonly List<ParameterFunction> VehicleParameterFunctions = new List<ParameterFunction>();
+        public static readonly List<ParameterFunction> ResetParameterFunctions = new List<ParameterFunction>();
+        public static readonly List<ParameterFunction> ClipCommunicationParameterFunctions = new List<ParameterFunction>();
+
+        static VersionBackend()
+        {
+            VehicleParameterFunctions.Add( null ); // "None" function
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle gravity (new method)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle gravity (old method)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle gravity (simple invert)", ParameterValueType.None ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle max speed (forward)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle max speed (backward)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change yellow booster multipiler", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change red booster multipiler", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change acceleration multipiler", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change acceleration multipiler (new)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change yellow booster effect time", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change red booster effect time", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( null ); // "Change vehicle property (Locked)" function
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change drift deceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change air deceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change steering strength", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change steepness acceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change roof deceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle grip", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change free wheeling brake", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle brake", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change water bounce", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change vehicle air stability", ParameterValueType.Number ) );
+
+            ResetParameterFunctions.Add( null ); // "None" function
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset all vehicle values to default", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle gravity", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle max speed", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle max speed (forward)", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle max speed (backward)", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset booster multipiler value", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset yellow booster multipiler value", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset red booster multipiler value", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset acceleration multipiler", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset booster effect time", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset yellow booster effect time", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset red booster effect time", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset drift deceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset air deceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset steering strength", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset steepness acceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset roof deceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle grip", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset free wheeling brake", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle brake", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset water bounce", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset vehicle air stability", ParameterValueType.None ) );
+
+            ClipCommunicationParameterFunctions.Add( null ); // "None" function
+            ClipCommunicationParameterFunctions.Add( new ParameterFunction( "Clip Communication/Communicate with another clip", ParameterValueType.Number ) );
+            ClipCommunicationParameterFunctions.Add( new ParameterFunction( "Clip Communication/Communicate with another clip and display", ParameterValueType.Number ) );
+            ClipCommunicationParameterFunctions.Add( new ParameterFunction( "Clip Communication/Add script to update list", ParameterValueType.Number ) );
+            ClipCommunicationParameterFunctions.Add( new ParameterFunction( "Clip Communication/Remove script from update list", ParameterValueType.Number ) );
+        }
+
+        public static ParameterFunction GetParameterFunction( uint catalogIndex, uint functionIndex )
+        {
+            switch ( catalogIndex )
+            {
+                case 1: // "Vehicle"
+                {
+                    return
+                    (
+                        functionIndex >= VehicleParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        VehicleParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                case 2: // "Reset" catalog
+                {
+                    return
+                    (
+                        functionIndex >= ResetParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        ResetParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                case 3: // "Clip Communication" catalog
+                {
+                    return
+                    (
+                        functionIndex >= ClipCommunicationParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        ClipCommunicationParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                default: // Unknown catalog
+                {
+                    return null;
+                }
+            }
+        }
+
+        protected new class Chunk03043055 : TMUnlimiter.VersionBackend.Chunk03043055
+        {
+            VersionBackend VersionBackend { get; set; }
+
+            public Chunk03043055( VersionBackend versionBackend )
+            {
+                this.VersionBackend = versionBackend;
+            }
+
+#pragma warning disable CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+            protected override void ArchiveBlock( GameBoxReader reader, uint blockIndex )
+            {
+                BlockData blockData = new BlockData( blockIndex );
+
+                blockData.InternalOverOverSizeChunkX = reader.ReadByte();
+                blockData.InternalOverOverSizeChunkY = reader.ReadByte();
+                blockData.InternalOverOverSizeChunkZ = reader.ReadByte();
+                blockData.InternalIsInverted = reader.ReadByte() != 0;
+                blockData.InternalBlockOffsetX = reader.ReadInt32();
+                blockData.InternalBlockOffsetY = reader.ReadInt32();
+                blockData.InternalBlockOffsetZ = reader.ReadInt32();
+                blockData.InternalBlockRotationX = reader.ReadUInt32();
+                blockData.InternalBlockRotationY = reader.ReadUInt32();
+                blockData.InternalBlockRotationZ = reader.ReadUInt32();
+
+                this.VersionBackend.BlocksData.Add( blockData );
+            }
+#pragma warning restore CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+
+            protected override void SetDecorationOffset( int offsetX, int offsetY, int offsetZ )
+            {
+                this.VersionBackend.DecorationOffsetX = offsetX;
+                this.VersionBackend.DecorationOffsetY = offsetY;
+                this.VersionBackend.DecorationOffsetZ = offsetZ;
+            }
+
+            protected override void SetSkyOnlyDecorationVisibility( bool skyOnlyDecorationVisibility )
+            {
+                this.VersionBackend.DecorationVisibility_SkyOnly = skyOnlyDecorationVisibility;
+            }
+
+            protected override ParameterFunction GetParameterFunction( uint catalogIndex, uint functionIndex )
+            {
+                return VersionBackend.GetParameterFunction( catalogIndex, functionIndex );
+            }
+
+            protected override void AddLegacyMediaClipMapping( uint mediaClipIndex, object resource )
+            {
+                this.VersionBackend.LegacyMediaClipResources.Add( new LegacyMediaClipResource( mediaClipIndex, resource ) );
+            }
+        }
+
+        bool DecorationVisibility_SkyOnly;
+        int DecorationOffsetX;
+        int DecorationOffsetY;
+        int DecorationOffsetZ;
+        readonly List<BlockData> BlocksData = new List<BlockData>();
+        readonly List<LegacyMediaClipResource> LegacyMediaClipResources = new List<LegacyMediaClipResource>();
+
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter12;
+        }
+
+#pragma warning disable CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+        public override void ArchiveOld( GameBoxReader reader )
+        {
+            new Chunk03043055( this ).Archive( reader );
+        }
+
+        public override void ArchiveNew( GameBoxReader reader, uint archiveVersion )
+        {
+            // No need to implement this chunk (at the moment)
+        }
+#pragma warning restore CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+
+        public override TMUnlimiter.BlockData[] GetBlocksData()
+        {
+            return this.BlocksData.ToArray();
+        }
+
+        public override bool IsDecorationOffsetApplied()
+        {
+            return this.DecorationOffsetX != 0 || this.DecorationOffsetY != 0 || this.DecorationOffsetZ != 0;
+        }
+
+        public override Vector3D GetDecorationOffset()
+        {
+            return new Vector3D( this.DecorationOffsetX, this.DecorationOffsetY, this.DecorationOffsetZ );
+        }
+
+        public override DecorationVisibility GetDecorationVisibility()
+        {
+            if ( this.DecorationVisibility_SkyOnly )
+            {
+                return DecorationVisibility.SkyOnly;
+            }
+            else
+            {
+                return DecorationVisibility.Default;
+            }
+        }
+
+        public override LegacyMediaClipResource[] GetLegacyMediaClipResources()
+        {
+            return this.LegacyMediaClipResources.ToArray();
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version13/BlockData.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version13/BlockData.cs
@@ -1,0 +1,108 @@
+using ManiaPlanetSharp.GameBox;
+
+namespace ManiaPlanetSharp.TMUnlimiter.Version13
+{
+    public class BlockData : TMUnlimiter.BlockData
+    {
+        public uint InternalOverOverSizeChunkX { get; set; }
+        public uint InternalOverOverSizeChunkY { get; set; }
+        public uint InternalOverOverSizeChunkZ { get; set; }
+        public bool InternalIsClassicTerrain { get; set; }
+        public bool InternalIsInverted { get; set; }
+        public Vector3D InternalBlockOffset { get; set; } = new Vector3D();
+        public Vector3D InternalBlockRotation { get; set; } = new Vector3D();
+        public Vector3D InternalBlockScale { get; set; } = new Vector3D( 1.0f, 1.0f, 1.0f );
+        public bool InternalIsSpawnPointFixEnabled { get; set; }
+        public bool InternalIsDynamic { get; set; }
+        public bool InternalIsInvisible { get; set; }
+        public bool InternalIsCollisionDisabled { get; set; }
+        public string InternalBlockGroup { get; set; }
+
+        public BlockData( uint blockIndex ) : base( blockIndex ) {}
+
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter13;
+        }
+
+        public override uint GetOverOverSizeChunkX()
+        {
+            return this.InternalOverOverSizeChunkX;
+        }
+
+        public override uint GetOverOverSizeChunkY()
+        {
+            return this.InternalOverOverSizeChunkY;
+        }
+
+        public override uint GetOverOverSizeChunkZ()
+        {
+            return this.InternalOverOverSizeChunkZ;
+        }
+
+        public override bool IsClassicTerrain()
+        {
+            return this.InternalIsClassicTerrain;
+        }
+
+        public override bool IsInverted()
+        {
+            return this.InternalIsInverted;
+        }
+
+        public override bool IsOffsetApplied()
+        {
+            return this.InternalBlockOffset.X != 0 || this.InternalBlockOffset.Y != 0 || this.InternalBlockOffset.Z != 0;
+        }
+
+        public override bool IsRotationApplied()
+        {
+            return this.InternalBlockRotation.X != 0 || this.InternalBlockRotation.Y != 0 || this.InternalBlockRotation.Z != 0;
+        }
+
+        public override bool IsScaleApplied()
+        {
+            return this.InternalBlockScale.X != 1 || this.InternalBlockScale.Y != 1 || this.InternalBlockScale.Z != 1;
+        }
+
+        public override Vector3D GetOffset()
+        {
+            return new Vector3D( this.InternalBlockOffset.X, this.InternalBlockOffset.Y, this.InternalBlockOffset.Z );
+        }
+
+        public override Vector3D GetRotation()
+        {
+            return new Vector3D( this.InternalBlockRotation.X, this.InternalBlockRotation.Y, this.InternalBlockRotation.Z );
+        }
+
+        public override Vector3D GetScale()
+        {
+            return new Vector3D( this.InternalBlockScale.X, this.InternalBlockScale.Y, this.InternalBlockScale.Z );
+        }
+
+        public override SpawnPointAlterMethod GetSpawnPointAlterMethod()
+        {
+            return this.InternalIsSpawnPointFixEnabled ? SpawnPointAlterMethod.Automatic : SpawnPointAlterMethod.None;
+        }
+
+        public override bool IsDynamic()
+        {
+            return this.InternalIsDynamic;
+        }
+
+        public override bool IsInvisible()
+        {
+            return this.InternalIsInvisible;
+        }
+
+        public override bool IsCollisionDisabled()
+        {
+            return this.InternalIsCollisionDisabled;
+        }
+
+        public override bool IsInBlockGroup( string blockGroup )
+        {
+            return this.InternalBlockGroup != null && this.InternalBlockGroup == blockGroup;
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version13/BlockFlags.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version13/BlockFlags.cs
@@ -1,0 +1,21 @@
+namespace ManiaPlanetSharp.TMUnlimiter.Version13
+{
+    [System.Flags]
+    enum BlockFlags : ushort
+    {
+        IsOutsideBoundaries = 1 << 0,
+        IsMoved = 1 << 1,
+        IsRotated = 1 << 2,
+        IsScaled = 1 << 3,
+        IsInverted = 1 << 4,
+        IsVanillaTerrain = 1 << 5,
+        IsSpawnPointFixEnabled = 1 << 6,
+        IsDynamic = 1 << 7,
+        IsInvisible = 1 << 8,
+        IsCollisionDisabled = 1 << 9,
+        IsClassicMode = 1 << 10,
+        IsClassicTerrain = 1 << 11,
+        HasIdentifier = 1 << 14,
+        Reserved = 1 << 15,
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version13/ChallengeFlags.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version13/ChallengeFlags.cs
@@ -1,0 +1,16 @@
+namespace ManiaPlanetSharp.TMUnlimiter.Version13
+{
+    [System.Flags]
+    enum ChallengeFlags : ushort
+    {
+        DecorationVisibility_SkyOnly = 1 << 0,
+        IsDecorationMoved = 1 << 1,
+        DecorationVisibility_Nothing = 1 << 2,
+        IsDecorationScaled = 1 << 3,
+        IsTrackBaseEmpty = 1 << 4,
+        IsVanillaMode = 1 << 5,
+        DecorationVisibility_Warp = 1 << 8,
+        IsPylonsDisabled = 1 << 9,
+        ReservedBit = 1 << 15,
+    };
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version13/VersionBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version13/VersionBackend.cs
@@ -1,0 +1,365 @@
+using System.Collections.Generic;
+using ManiaPlanetSharp.GameBox;
+using ManiaPlanetSharp.GameBox.Parsing;
+
+namespace ManiaPlanetSharp.TMUnlimiter.Version13
+{
+    public class VersionBackend : TMUnlimiter.VersionBackend
+    {
+        public static readonly List<ParameterFunction> VehicleParameterFunctions = new List<ParameterFunction>();
+        public static readonly List<ParameterFunction> ResetParameterFunctions = new List<ParameterFunction>();
+        public static readonly List<ParameterFunction> WorldParameterFunctions = new List<ParameterFunction>();
+        public static readonly List<ParameterFunction> BlockParameterFunctions = new List<ParameterFunction>();
+        public static readonly List<ParameterFunction> VehicleMultipliersParameterFunctions = new List<ParameterFunction>();
+
+        static VersionBackend()
+        {
+            VehicleParameterFunctions.Add( null ); // "None" function
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Gravity", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Gravity (Total)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Simple Gravity Inversion", ParameterValueType.None ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Max Speed (Forward)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Max Speed (Backward)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Yellow Booster Strength", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Red Booster Strength", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Acceleration (Add)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Acceleration Multiplier", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Yellow Booster Duration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Red Boost Duration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Drift Deceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Air Deceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Steering Strength", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Steepness Acceleration", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Body Friction", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Vehicle Grip", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Idleness Properties", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Braking Properties", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Water Bounce Strength", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Air Stability", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Scale Vehicle", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( null ); // "Vehicle/Change Engine Pitch" - never implemented in 1.3
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Change Engine Volume", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Add Force (Axis X)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Add Force (Axis Y)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Add Force (Axis Z)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Set Gravity (Axis X)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Set Gravity (Axis Y)", ParameterValueType.Number ) );
+            VehicleParameterFunctions.Add( new ParameterFunction( "Vehicle/Set Gravity (Axis Z)", ParameterValueType.Number ) );
+
+            ResetParameterFunctions.Add( null ); // "None" function
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Everything", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Gravity", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Max Speed", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Forward Max Speed", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Backward Max Speed", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Booster Strength", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Yellow Booster Strength", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Red Booster Strength", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Acceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Booster Duration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Yellow Booster Duration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Red Booster Duration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Drift Deceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Air Deceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Steering Strength", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Steepness Acceleration", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Body Friction", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Vehicle Grip", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Idleness Properties", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Braking Properties", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Water Bounce", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Air Stability", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Engine Sound", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Engine Scale", ParameterValueType.None ) );
+            ResetParameterFunctions.Add( new ParameterFunction( "Reset/Reset Gravity Force", ParameterValueType.None ) );
+
+            WorldParameterFunctions.Add( null ); // "None" function
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Call Clip", ParameterValueType.Number ) );
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Call And Display Clip", ParameterValueType.Number ) );
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Add Script", ParameterValueType.Number ) );
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Remove Script", ParameterValueType.Number ) );
+            WorldParameterFunctions.Add( null ); // Not used space for a function
+            WorldParameterFunctions.Add( null ); // Not used space for a function
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Set Mood Time", ParameterValueType.Number ) );
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Enable Dynamic Mood", ParameterValueType.None ) );
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Disable Dynamic Mood", ParameterValueType.None ) );
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Set Dynamic Mood Speed", ParameterValueType.Number ) );
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Enable Magnets", ParameterValueType.None ) );
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Disable Magnets", ParameterValueType.None ) );
+            WorldParameterFunctions.Add( new ParameterFunction( "World/Toggle Hard Magnets", ParameterValueType.None ) );
+
+            BlockParameterFunctions.Add( null ); // "None" function
+            BlockParameterFunctions.Add( new ParameterFunction( "Block/Show Block", ParameterValueType.String ) );
+            BlockParameterFunctions.Add( new ParameterFunction( "Block/Hide Block", ParameterValueType.String ) );
+            BlockParameterFunctions.Add( new ParameterFunction( "Block/Disable Block Collision", ParameterValueType.String ) );
+            BlockParameterFunctions.Add( new ParameterFunction( "Block/Enable Block Collision", ParameterValueType.String ) );
+            BlockParameterFunctions.Add( null ); // Not used space for a function
+            BlockParameterFunctions.Add( null ); // Not used space for a function
+            BlockParameterFunctions.Add( null ); // Not used space for a function
+            BlockParameterFunctions.Add( null ); // Not used space for a function
+            BlockParameterFunctions.Add( null ); // Not used space for a function
+            BlockParameterFunctions.Add( null ); // Not used space for a function
+            BlockParameterFunctions.Add( null ); // Not used space for a function
+            BlockParameterFunctions.Add( null ); // Not used space for a function
+
+            VehicleMultipliersParameterFunctions.Add( null ); // "None" function
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Gravity", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Max Speed (Forward)", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Max Speed (Backward)", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Yellow Booster Strength", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Red Booster Strength", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Acceleration Multipiler", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Yellow Booster Duration", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Red Booster Duration", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Drift Deceleration", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Air Deceleration", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Steering Strength", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Steepness Acceleration", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Body Friction", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Vehicle Grip", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Free Wheeling Brake", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Vehicle Brake", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Water Bounce Strength", ParameterValueType.Number ) );
+            VehicleMultipliersParameterFunctions.Add( new ParameterFunction( "Vehicle (Multipliers)/Change Air Stability", ParameterValueType.Number ) );
+        }
+
+        public static ParameterFunction GetParameterFunction( uint catalogIndex, uint functionIndex )
+        {
+            switch ( catalogIndex )
+            {
+                case 0: // "Vehicle" catalog
+                {
+                    return
+                    (
+                        functionIndex >= VehicleParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        VehicleParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                case 1: // "Reset" catalog
+                {
+                    return
+                    (
+                        functionIndex >= ResetParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        ResetParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                case 2: // "World" catalog
+                {
+                    return
+                    (
+                        functionIndex >= WorldParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        WorldParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                case 3: // "Block" catalog
+                {
+                    return
+                    (
+                        functionIndex >= BlockParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        BlockParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                case 4: // "Vehicle (Multipliers)" catalog
+                {
+                    return
+                    (
+                        functionIndex >= VehicleMultipliersParameterFunctions.Count
+                        ?
+                        null
+                        :
+                        VehicleMultipliersParameterFunctions[ ( int )functionIndex ]
+                    );
+                }
+                default: // Unknown catalog
+                {
+                    return null;
+                }
+            }
+        }
+
+        ChallengeFlags ChallengeFlags;
+        Vector3D DecorationOffset = new Vector3D();
+        Vector3D DecorationScale = new Vector3D( 1.0f, 1.0f, 1.0f );
+        readonly List<BlockData> BlocksData = new List<BlockData>();
+
+        public static byte[] DecryptChunkData( byte[] cryptedChunkData )
+        {
+            if ( cryptedChunkData == null )
+            {
+                return null;
+            }
+
+            for ( uint offset = 0; offset < cryptedChunkData.Length; offset++ )
+            {
+                uint data = cryptedChunkData[ offset ];
+                uint hash = ( uint )( cryptedChunkData.Length * ( ( cryptedChunkData.Length * 2 ) - offset ) );
+
+                hash ^= 0xead9c8b3;
+                hash += offset * 3 % 0x7f;
+
+                if ( offset % 5 < 2 )
+                {
+                    hash = ~hash;
+                }
+
+                cryptedChunkData[ offset ] = ( byte )~( data ^ hash );
+            }
+
+            return cryptedChunkData;
+        }
+
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter13;
+        }
+
+#pragma warning disable CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+        public override void ArchiveOld( GameBoxReader reader )
+        {
+            this.ChallengeFlags = ( ChallengeFlags )reader.ReadUInt16();
+
+            if ( this.ChallengeFlags.HasFlag( ChallengeFlags.ReservedBit ) )
+            {
+                return;
+            }
+
+            if ( !this.ChallengeFlags.HasFlag( ChallengeFlags.DecorationVisibility_Nothing ) )
+            {
+                if ( this.ChallengeFlags.HasFlag( ChallengeFlags.IsDecorationMoved ) )
+                {
+                    this.DecorationOffset = reader.ReadVec3D();
+                }
+
+                if ( this.ChallengeFlags.HasFlag( ChallengeFlags.IsDecorationScaled ) )
+                {
+                    this.DecorationScale = reader.ReadVec3D();
+                }
+            }
+
+            uint blockCount = reader.ReadUInt32();
+
+            while ( blockCount-- != 0 )
+            {
+                BlockData blockData = new BlockData( reader.ReadUInt32() );
+                BlockFlags blockFlags = ( BlockFlags )reader.ReadUInt16();
+
+                // outside boundaries
+                if ( blockFlags.HasFlag( BlockFlags.IsOutsideBoundaries ) )
+                {
+                    blockData.InternalOverOverSizeChunkX = reader.ReadByte();
+                    blockData.InternalOverOverSizeChunkY = reader.ReadByte();
+                    blockData.InternalOverOverSizeChunkZ = reader.ReadByte();
+                }
+
+                blockData.InternalIsInverted = blockFlags.HasFlag( BlockFlags.IsInverted );
+                blockData.InternalIsDynamic = blockFlags.HasFlag( BlockFlags.IsDynamic );
+                blockData.InternalIsInvisible = blockFlags.HasFlag( BlockFlags.IsInvisible );
+                blockData.InternalIsCollisionDisabled = blockFlags.HasFlag( BlockFlags.IsCollisionDisabled );
+                blockData.InternalIsSpawnPointFixEnabled = blockFlags.HasFlag( BlockFlags.IsSpawnPointFixEnabled );
+
+                if ( blockFlags.HasFlag( BlockFlags.IsVanillaTerrain ) )
+                {
+                    continue;
+                }
+
+                blockData.InternalIsClassicTerrain = blockFlags.HasFlag( BlockFlags.IsClassicTerrain );
+
+                if ( blockFlags.HasFlag( BlockFlags.IsMoved ) )
+                {
+                    blockData.InternalBlockOffset = reader.ReadVec3D();
+                }
+
+                if ( blockFlags.HasFlag( BlockFlags.IsRotated ) )
+                {
+                    blockData.InternalBlockRotation = reader.ReadVec3D();
+                }
+
+                if ( blockFlags.HasFlag( BlockFlags.IsScaled ) )
+                {
+                    blockData.InternalBlockScale = reader.ReadVec3D();
+                }
+
+                if ( blockFlags.HasFlag( BlockFlags.HasIdentifier ) )
+                {
+                    blockData.InternalBlockGroup = reader.ReadString();
+                }
+            }
+
+            // Skip unused value
+            reader.Skip( 4 );
+        }
+
+        public override void ArchiveNew( GameBoxReader reader, uint archiveVersion )
+        {
+            // No need to implement this chunk (at the moment)
+        }
+#pragma warning restore CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+
+        public override TMUnlimiter.BlockData[] GetBlocksData()
+        {
+            return this.BlocksData.ToArray();
+        }
+
+        public override bool IsTrackBaseEmpty()
+        {
+            return this.ChallengeFlags.HasFlag( ChallengeFlags.IsTrackBaseEmpty );
+        }
+
+        public override bool IsPylonsDisabled()
+        {
+            return this.ChallengeFlags.HasFlag( ChallengeFlags.IsPylonsDisabled );
+        }
+
+        public override bool IsDecorationOffsetApplied()
+        {
+            return this.DecorationOffset.X != 0.0f && this.DecorationOffset.Y != 0.0f && this.DecorationOffset.Z != 0.0f;
+        }
+
+        public override bool IsDecorationScaleApplied()
+        {
+            return this.DecorationScale.X != 1.0f && this.DecorationScale.Y != 1.0f && this.DecorationScale.Z != 1.0f;
+        }
+
+        public override Vector3D GetDecorationOffset()
+        {
+            return new Vector3D( this.DecorationOffset.X, this.DecorationOffset.Y, this.DecorationOffset.Z );
+        }
+
+        public override Vector3D GetDecorationScale()
+        {
+            return new Vector3D( this.DecorationScale.X, this.DecorationScale.Y, this.DecorationScale.Z );
+        }
+
+        public override DecorationVisibility GetDecorationVisibility()
+        {
+            if ( this.ChallengeFlags.HasFlag( ChallengeFlags.DecorationVisibility_SkyOnly ) )
+            {
+                return DecorationVisibility.SkyOnly;
+            }
+            else if ( this.ChallengeFlags.HasFlag( ChallengeFlags.DecorationVisibility_Warp ) )
+            {
+                return DecorationVisibility.WarpOnly;
+            }
+            else if ( this.ChallengeFlags.HasFlag ( ChallengeFlags.DecorationVisibility_Nothing ) )
+            {
+                return DecorationVisibility.Nothing;
+            }
+            else
+            {
+                return DecorationVisibility.Default;
+            }
+        }
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version13/VersionBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version13/VersionBackend.cs
@@ -253,6 +253,8 @@ namespace ManiaPlanetSharp.TMUnlimiter.Version13
             while ( blockCount-- != 0 )
             {
                 BlockData blockData = new BlockData( reader.ReadUInt32() );
+                this.BlocksData.Add( blockData );
+
                 BlockFlags blockFlags = ( BlockFlags )reader.ReadUInt16();
 
                 // outside boundaries

--- a/src/ManiaPlanetSharp/TMUnlimiter/Version20/VersionBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/Version20/VersionBackend.cs
@@ -1,0 +1,19 @@
+using ManiaPlanetSharp.GameBox.Parsing;
+
+namespace ManiaPlanetSharp.TMUnlimiter.Version20
+{
+    public class VersionBackend : TMUnlimiter.VersionBackend
+    {
+        public override TrackVersion GetTrackVersion()
+        {
+            return TrackVersion.Unlimiter20;
+        }
+
+#pragma warning disable CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+        public override void ArchiveNew( GameBoxReader reader, uint archiveVersion )
+        {
+            // No need to implement this chunk (at the moment)
+        }
+#pragma warning restore CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+    }
+}

--- a/src/ManiaPlanetSharp/TMUnlimiter/VersionBackend.cs
+++ b/src/ManiaPlanetSharp/TMUnlimiter/VersionBackend.cs
@@ -1,0 +1,155 @@
+using System;
+using ManiaPlanetSharp.GameBox;
+using ManiaPlanetSharp.GameBox.Parsing;
+
+namespace ManiaPlanetSharp.TMUnlimiter
+{
+    public abstract class VersionBackend
+    {
+        protected abstract class Chunk03043055
+        {
+            protected abstract void ArchiveBlock( GameBoxReader reader, uint blockIndex );
+            protected abstract void SetDecorationOffset( int offsetX, int offsetY, int offsetZ );
+            protected abstract void SetSkyOnlyDecorationVisibility( bool skyOnlyDecorationVisibility );
+            protected abstract ParameterFunction GetParameterFunction( uint catalogIndex, uint functionIndex );
+            protected abstract void AddLegacyMediaClipMapping( uint mediaClipIndex, object resource );
+
+#pragma warning disable CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+            public void Archive( GameBoxReader reader )
+            {
+                this.SetDecorationOffset( reader.ReadInt32(), reader.ReadInt32(), reader.ReadInt32() );
+                this.SetSkyOnlyDecorationVisibility( reader.ReadByte() != 0 );
+
+                uint blockDataCount = reader.ReadUInt32();
+
+                while ( blockDataCount-- != 0 )
+                {
+                    this.ArchiveBlock( reader, reader.ReadUInt32() );
+                }
+
+                uint mediaClipMappingCount = reader.ReadUInt32();
+
+                while ( mediaClipMappingCount-- != 0 )
+                {
+                    uint mediaClipIndex = reader.ReadUInt32();
+                    byte resourceType = reader.ReadByte();
+
+                    switch ( resourceType )
+                    {
+                        case 0: // Parameter Set
+                        {
+                            ParameterSet parameterSet = new ParameterSet();
+
+                            for ( uint parameterIndex = 0; parameterIndex < 4; parameterIndex++ )
+                            {
+                                ParameterFunction parameterFunction = this.GetParameterFunction( reader.ReadByte(), reader.ReadByte() );
+                                float value = reader.ReadFloat();
+
+                                if ( parameterFunction == null )
+                                {
+                                    continue;
+                                }
+
+                                if ( parameterFunction.ValueType == ParameterValueType.Number )
+                                {
+                                    parameterSet.Parameters.Add( new ParameterNumber( parameterFunction, value ) );
+                                }
+                                else
+                                {
+                                    parameterSet.Parameters.Add( new Parameter( parameterFunction ) );
+                                }
+                            }
+
+                            if ( parameterSet.Parameters.Count > 0 )
+                            {
+                                this.AddLegacyMediaClipMapping( mediaClipIndex, parameterSet );
+                            }
+
+                            break;
+                        }
+                        case 1: // Legacy Script
+                        {
+                            // Byte code size is an unsigned integer, but MemoryStream works on integers instead...
+                            int byteCodeSize = reader.ReadInt32();
+
+                            if ( byteCodeSize != 0 )
+                            {
+                                this.AddLegacyMediaClipMapping( mediaClipIndex, new LegacyScript( reader.ReadRaw( byteCodeSize ), LegacyScriptExecutionType.TriggerOnce ) );
+                            }
+
+                            break;
+                        }
+                        default: // Unknown
+                        {
+                            throw new NotSupportedException( $"Unknown resource type (resourceType = {resourceType}). Only parameter sets and legacy scripts are supported." );
+                        }
+                    }
+                }
+
+                // Skip fake 0xfacade01
+                reader.Skip( 4 );
+            }
+#pragma warning restore CA1062 // Validate arguments of public methods -- Reader is always guaranteed to be non-null.
+        }
+
+        public abstract TrackVersion GetTrackVersion();
+
+        // Read data saved from legacy version of TMUnlimiter (1.3, 1.2 and 1.1)
+        public virtual void ArchiveOld( GameBoxReader reader )
+        {
+            // By default function is empty and ready for override
+        }
+
+        // Read data saved from modern version of TMUnlimiter (^2.0.0)
+        public virtual void ArchiveNew( GameBoxReader reader, uint archiveVersion )
+        {
+            // No need to implement this method (at the moment)
+        }
+
+        // Get additional data associated with each block
+        public virtual BlockData[] GetBlocksData()
+        {
+            return null;
+        }
+
+        public virtual bool IsTrackBaseEmpty()
+        {
+            return false;
+        }
+
+        public virtual bool IsPylonsDisabled()
+        {
+            return false;
+        }
+
+        public virtual bool IsDecorationOffsetApplied()
+        {
+            return false;
+        }
+
+        public virtual bool IsDecorationScaleApplied()
+        {
+            return false;
+        }
+
+        public virtual Vector3D GetDecorationOffset()
+        {
+            return new Vector3D();
+        }
+
+        public virtual Vector3D GetDecorationScale()
+        {
+            return new Vector3D( 1.0f, 1.0f, 1.0f );
+        }
+
+        public virtual DecorationVisibility GetDecorationVisibility()
+        {
+            return DecorationVisibility.Default;
+        }
+
+        public virtual LegacyMediaClipResource[] GetLegacyMediaClipResources()
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds support for all TMUnlimiter chunks written in the ``.Challenge.Gbx`` file:

- ``0x03043055`` chunk (used in TMUnlimiter 1.1 and TMUnlimiter 1.2)
- ``0x3f001000`` chunk (used in TMUnlimiter 1.3)
- ``0x3f001001``, ``0x3f001002`` and ``0x3f001003`` chunk (used in TMUnlimiter 2.0)

Also, three new virtual properties are added to the ``MapMetadataProvider`` class:
- ``ChallengeBackend`` which is the core class that holds processed TMUnlimiter data.
- ``ParameterSets`` providing a way to access parameter sets stored in separate chunks in TMUnlimiter 1.3 tracks.
- ``LegacyScripts`` similar to parameter sets but for the legacy scripts.

All changes were tested locally on 500 sample tracks with different track versions from TMUnlimiter 1.1 to TMUnlimiter 2.0 (Vanilla tracks were also included) and all were successfully detected.