### PR TITLE
Improve 0x0304301f chunk implementation (and more)

### DIFF
--- a/src/ManiaPlanetSharp/GameBox/GameBoxFile.cs
+++ b/src/ManiaPlanetSharp/GameBox/GameBoxFile.cs
@@ -127,7 +127,7 @@ namespace ManiaPlanetSharp.GameBox
                 {
                     if (ParserFactory.TryGetChunkParser(chunkId, out IChunkParser<Chunk> parser))
                     {
-                        using (GameBoxReader nestedReader = reader.GetNestedLengthLimitedReader((int)this.HeaderChunkEntries[i].ChunkSize))
+                        using (GameBoxReader nestedReader = new GameBoxReader(new MemoryStream(reader.ReadRaw((int)this.HeaderChunkEntries[i].ChunkSize))))
                             headerChunks[i] = parser.Parse(nestedReader, chunkId);
                     }
                     else

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapChallengeParameterChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapChallengeParameterChunk.cs
@@ -108,10 +108,10 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
                     }
                     case 0x03_05b_001u:
                     {
-                        reader.ReadString(); // ignored
-                        reader.ReadString(); // ignored
-                        reader.ReadString(); // ignored
-                        reader.ReadString(); // ignored
+                        result.Tip = reader.ReadString();
+                        result.Tip = reader.ReadString();
+                        result.Tip = reader.ReadString();
+                        result.Tip = reader.ReadString();
                         break;
                     }
                     case 0x03_05b_002u:
@@ -204,6 +204,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
         public uint AuthorTime { get; set; }
         public uint TimeLimit { get; set; }
         public uint AuthorScore { get; set; }
+        public string Tip { get; set; }
     }
 
     public enum MapKind

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapChallengeParameterChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapChallengeParameterChunk.cs
@@ -1,26 +1,209 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 #pragma warning disable CS0618 //Disable obsoleteness-warnings
 
 namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
 {
-    //[Chunk(0x03043011)]
+    [Chunk(0x03043011)]
     public class MapChallengeParameterChunk
         : Chunk
     {
-        [Property]
-        public Node CollectorList { get; set; }
+        [Property, CustomParserMethod( nameof( ReadCollectorListRef ) )]
+        public CollectorListChunk CollectorList { get; set; }
+
+        [Property, CustomParserMethod( nameof( ReadChallengeParametersRef ) )]
+        public ChallengeParameters ChallengeParameters { get; set; }
 
         [Property]
-        public Node ChallengeParameters { get; set; }
-
-        [Property]
-        [Obsolete("Raw Value, use MapChallengeParameterChunk.Kind instead", false)]
+        [Obsolete( "Raw Value, use MapChallengeParameterChunk.Kind instead", false )]
         public uint KindU { get; set; }
 
-        public MapKind Kind { get => (MapKind)(byte)this.KindU; }
+        public MapKind Kind { get => ( MapKind )( byte )this.KindU; }
+
+        public CollectorListChunk ReadCollectorListRef(GameBoxReader reader)
+        {
+            // (instanceIndex) No instance expected to be read.
+            if ( reader.ReadUInt32() == uint.MaxValue )
+            {
+                return null;
+            }
+
+            // (classId) Reference to an existing CGameCtnCollectorList instance. Since we cannot
+            // maintain a list of instances instantiated from there, we simply return null.
+            if ( reader.ReadUInt32() != 0x03_01b_000 )
+            {
+                reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
+                return null;
+            }
+
+            CollectorListChunk result = new CollectorListChunk();
+            uint chunkId = reader.ReadUInt32();
+
+            do
+            {
+                switch ( chunkId )
+                {
+                    case 0x03_01b_000u:
+                    {
+                        result.Archive = new CollectorStock[ reader.ReadUInt32() ];
+
+                        for ( uint collectorStockIndex = 0; collectorStockIndex < result.Archive.Length; collectorStockIndex++ )
+                        {
+                            CollectorStock collectorStock = result.Archive[ collectorStockIndex ] = new CollectorStock();
+                            collectorStock.BlockName = reader.ReadLookbackString();
+                            collectorStock.Collection = reader.ReadLookbackString();
+                            collectorStock.Author = reader.ReadLookbackString();
+                            collectorStock.Data = reader.ReadUInt32();
+                        }
+
+                        break;
+                    }
+                    default:
+                    {
+                        throw new NotSupportedException( $"Unsupported CGameCtnCollectorList chunk: {chunkId:X8}" );
+                    }
+                }
+
+                chunkId = reader.ReadUInt32();
+            }
+            while ( chunkId != GameBoxReader.EndMarkerClassId );
+
+            return result;
+        }
+
+        public ChallengeParameters ReadChallengeParametersRef(GameBoxReader reader)
+        {
+            // (instanceIndex) No instance expected to be read.
+            if ( reader.ReadUInt32() == uint.MaxValue )
+            {
+                return null;
+            }
+
+            // (classId) Reference to an existing CGameCtnChallengeParameters instance. Since we cannot
+            // maintain a list of instances instantiated from there, we simply return null.
+            if ( reader.ReadUInt32() != 0x03_05b_000 )
+            {
+                reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
+                return null;
+            }
+
+            ChallengeParameters result = new ChallengeParameters();
+            uint chunkId = reader.ReadUInt32();
+
+            do
+            {
+                switch ( chunkId )
+                {
+                    case 0x03_05b_000u:
+                    {
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        break;
+                    }
+                    case 0x03_05b_001u:
+                    {
+                        reader.ReadString(); // ignored
+                        reader.ReadString(); // ignored
+                        reader.ReadString(); // ignored
+                        reader.ReadString(); // ignored
+                        break;
+                    }
+                    case 0x03_05b_002u:
+                    {
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadFloat(); // ignored
+                        reader.ReadFloat(); // ignored
+                        reader.ReadFloat(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        break;
+                    }
+                    case 0x03_05b_003u:
+                    {
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadFloat(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        break;
+                    }
+                    case 0x03_05b_004u:
+                    {
+                        result.BronzeTime = reader.ReadUInt32();
+                        result.SilverTime = reader.ReadUInt32();
+                        result.GoldTime = reader.ReadUInt32();
+                        result.AuthorTime = reader.ReadUInt32();
+                        reader.ReadUInt32(); // ignored
+                        break;
+                    }
+                    case 0x03_05b_005u:
+                    {
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        reader.ReadUInt32(); // ignored
+                        break;
+                    }
+                    case 0x03_05b_006u:
+                    {
+                        uint length = reader.ReadUInt32();
+
+                        for ( uint ignoredIndex = 0; ignoredIndex < length; ignoredIndex++ )
+                        {
+                            reader.ReadUInt32(); // ignored
+                        }
+
+                        break;
+                    }
+                    case 0x03_05b_007u:
+                    {
+                        result.TimeLimit = reader.ReadUInt32();
+                        break;
+                    }
+                    case 0x03_05b_008u:
+                    {
+                        result.TimeLimit = reader.ReadUInt32();
+                        result.AuthorScore = reader.ReadUInt32();
+                        break;
+                    }
+                    default:
+                    {
+                        throw new NotSupportedException( $"Unsupported CGameCtnChallengeParameters chunk: {chunkId:X8}" );
+                    }
+                }
+
+                chunkId = reader.ReadUInt32();
+            }
+            while ( chunkId != GameBoxReader.EndMarkerClassId );
+
+            return result;
+        }
+    }
+
+    public class ChallengeParameters
+    {
+        public uint BronzeTime { get; set; }
+        public uint SilverTime { get; set; }
+        public uint GoldTime { get; set; }
+        public uint AuthorTime { get; set; }
+        public uint TimeLimit { get; set; }
+        public uint AuthorScore { get; set; }
     }
 
     public enum MapKind

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapChunk.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ManiaPlanetSharp.GameBox.Types;
 
 namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
@@ -184,6 +184,12 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
                         result.Text = reader.ReadString();
                         result.PackDesc = reader.ReadFileReference();
                         result.ParentPackDesc = reader.ReadFileReference();
+                        break;
+                    }
+                    case 0x03_059_003u:
+                    {
+                        reader.ReadUInt32(); // Version, at the time of implementation - not used
+                        result.ForegroundPackDesc = reader.ReadFileReference();
                         break;
                     }
                     default:

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/TMUnlimiter/ChallengeBackendChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/TMUnlimiter/ChallengeBackendChunk.cs
@@ -20,6 +20,17 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks.TMUnlimiter
                 // TMUnlimiter 1.1 and 1.2 chunk
                 case 0x03_043_055u:
                 {
+                    // Check that the skip marker has been written (since ManiaPlanet maps) to skip unnecessary exception.
+                    if ( reader.ReadUInt32() == GameBoxReader.SkipMarker )
+                    {
+                        reader.Skip( reader.ReadInt32() );
+                        return null;
+                    }
+                    else
+                    {
+                        reader.Stream.Seek( -4, SeekOrigin.Current );
+                    }
+
                     byte chunkVersion = reader.ReadByte();
 
                     switch ( chunkVersion )
@@ -50,7 +61,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks.TMUnlimiter
                 {
                     ChallengeBackend = new ChallengeBackend( TrackVersion.Unlimiter13 );
 
-                    reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
+                    reader.Stream.Seek( -4, SeekOrigin.Current );
                     // Chunk size is an unsigned integer, but MemoryStream works on integers instead...
                     int chunkSize = reader.ReadInt32();
 
@@ -73,7 +84,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks.TMUnlimiter
                 case 0x3f_001_002u:
                 case 0x3f_001_003u:
                 {
-                    reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
+                    reader.Stream.Seek( -4, SeekOrigin.Current );
                     // Chunk size is an unsigned integer, but MemoryStream works on integers instead...
                     int chunkSize = reader.ReadInt32();
 

--- a/src/ManiaPlanetSharp/GameBox/Parsing/GameBoxReader.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/GameBoxReader.cs
@@ -245,9 +245,9 @@ namespace ManiaPlanetSharp.GameBox.Parsing
                 LookbackStrings.Add(newString);
                 return newString;
             }
-            if (index == uint.MaxValue) //?
+            if (index == uint.MaxValue)
             {
-                return string.Empty;
+                return "Unassigned";
             }
             if ((index & 0x3fffffff) == index)
             {

--- a/src/ManiaPlanetSharp/GameBox/Parsing/GameBoxReader.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/GameBoxReader.cs
@@ -350,7 +350,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing
                 reference.Checksum = this.ReadRaw(32);
             }
             reference.FilePath = this.ReadString();
-            if (reference.FilePath?.Length > 0 && reference.Version >= 1)
+            if ((reference.FilePath?.Length > 0 && reference.Version >= 1) || reference.Version >= 3)
             {
                 reference.LocatorUrl = this.ReadString();
             }

--- a/src/ManiaPlanetSharp/GameBox/Types/GameCtnBlockSkin.cs
+++ b/src/ManiaPlanetSharp/GameBox/Types/GameCtnBlockSkin.cs
@@ -5,5 +5,6 @@
         public string Text { get; set; }
         public FileReference PackDesc { get; set; }
         public FileReference ParentPackDesc { get; set; }
+        public FileReference ForegroundPackDesc { get; set; }
     }
 }

--- a/src/ManiaPlanetSharp/GameBox/Types/GameCtnBlockSkin.cs
+++ b/src/ManiaPlanetSharp/GameBox/Types/GameCtnBlockSkin.cs
@@ -1,0 +1,9 @@
+﻿namespace ManiaPlanetSharp.GameBox.Types
+{
+    public class GameCtnBlockSkin
+    {
+        public string Text { get; set; }
+        public FileReference PackDesc { get; set; }
+        public FileReference ParentPackDesc { get; set; }
+    }
+}


### PR DESCRIPTION
This pull request makes changes around few things:

- Create a separate ``GameBoxReader`` instance when parsing each header chunk. Technically (from the game perspective), header chunks are archived separately, so they do not share the pool of lookback strings.
- Restore the previously commented ``0x03043011`` chunk (probably because the node reference implementation was not implemented correctly). Overwrite nodes within the chunk with custom parser methods that read node references correctly (with some trade-offs).
- Return "Unassigned" string if lookback string index is -1
- Overwrite block archiving in ``0x0304301f`` chunk. Added support for chunk version 6 (since ManiaPlanet 1). Added additional archiving routines when some block flags are set. Added block skin archiving (another node reference specific implementation).

This implementation has been tested on TMF track files, but I will be doing additional tests on maps created with ManiaPlanet and TrackMania 2020.