### PR TITLE
Fix memory spikes and incorrect parse with legacy chunk ids

### DIFF
--- a/src/ManiaPlanetSharp/GameBox/GameBoxFile.cs
+++ b/src/ManiaPlanetSharp/GameBox/GameBoxFile.cs
@@ -294,6 +294,9 @@ namespace ManiaPlanetSharp.GameBox
                     {
                         try
                         {
+                            // Map potentially old chunk id and use remapped chunk id to look up skippable flag.
+                            id = ClassIds.MapToNewEngine( id );
+
                             //Compared to the solution via the lambda that was commented out below, this saves a lot (up to multiple million in big files) allocations
                             bool skippable = false;
                             foreach (var parserId in parser.ParseableIds)

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Collector/CollectorListChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Collector/CollectorListChunk.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
 {
-    [Chunk(0x0301B000)]
+    //[Chunk(0x0301B000)]
     public class CollectorListChunk
         : Chunk
     {        

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapChallengeParameterChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapChallengeParameterChunk.cs
@@ -30,14 +30,14 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
 
             // (classId) Reference to an existing CGameCtnCollectorList instance. Since we cannot
             // maintain a list of instances instantiated from there, we simply return null.
-            if ( reader.ReadUInt32() != 0x03_01b_000 )
+            if ( ClassIds.MapToNewEngine( reader.ReadUInt32() ) != 0x03_01b_000 )
             {
                 reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
                 return null;
             }
 
             CollectorListChunk result = new CollectorListChunk();
-            uint chunkId = reader.ReadUInt32();
+            uint chunkId = ClassIds.MapToNewEngine( reader.ReadUInt32() );
 
             do
             {
@@ -64,7 +64,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
                     }
                 }
 
-                chunkId = reader.ReadUInt32();
+                chunkId = ClassIds.MapToNewEngine( reader.ReadUInt32() );
             }
             while ( chunkId != GameBoxReader.EndMarkerClassId );
 
@@ -81,14 +81,14 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
 
             // (classId) Reference to an existing CGameCtnChallengeParameters instance. Since we cannot
             // maintain a list of instances instantiated from there, we simply return null.
-            if ( reader.ReadUInt32() != 0x03_05b_000 )
+            if ( ClassIds.MapToNewEngine( reader.ReadUInt32() ) != 0x03_05b_000 )
             {
                 reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
                 return null;
             }
 
             ChallengeParameters result = new ChallengeParameters();
-            uint chunkId = reader.ReadUInt32();
+            uint chunkId = ClassIds.MapToNewEngine( reader.ReadUInt32() );
 
             do
             {
@@ -188,7 +188,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
                     }
                 }
 
-                chunkId = reader.ReadUInt32();
+                chunkId = ClassIds.MapToNewEngine( reader.ReadUInt32() );
             }
             while ( chunkId != GameBoxReader.EndMarkerClassId );
 

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Map/MapChunk.cs
@@ -155,14 +155,14 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
 
             // (classId) Reference to an existing CGameCtnBlockSkin instance. Since we cannot
             // maintain a list of instances instantiated from there, we simply return null.
-            if ( reader.ReadUInt32() != 0x03_059_000u )
+            if ( ClassIds.MapToNewEngine( reader.ReadUInt32() ) != 0x03_059_000u )
             {
                 reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
                 return null;
             }
 
             GameCtnBlockSkin result = new GameCtnBlockSkin();
-            uint chunkId = reader.ReadUInt32();
+            uint chunkId = ClassIds.MapToNewEngine( reader.ReadUInt32() );
 
             do
             {
@@ -199,7 +199,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
                     }
                 }
 
-                chunkId = reader.ReadUInt32();
+                chunkId = ClassIds.MapToNewEngine( reader.ReadUInt32() );
             }
             while ( chunkId != GameBoxReader.EndMarkerClassId );
 
@@ -216,14 +216,14 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
 
             // (classId) Reference to an existing CGameWaypointSpecialProperty instance. Since we cannot
             // maintain a list of instances instantiated from there, we simply return null.
-            if ( reader.ReadUInt32() != 0x2e_009_000u )
+            if ( ClassIds.MapToNewEngine( reader.ReadUInt32() ) != 0x2e_009_000u )
             {
                 reader.Stream.Seek( -4, System.IO.SeekOrigin.Current );
                 return null;
             }
 
             WaypointSpecialPropertyChunk result = new WaypointSpecialPropertyChunk();
-            uint chunkId = reader.ReadUInt32();
+            uint chunkId = ClassIds.MapToNewEngine( reader.ReadUInt32() );
 
             do
             {
@@ -267,7 +267,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
                     }
                 }
 
-                chunkId = reader.ReadUInt32();
+                chunkId = ClassIds.MapToNewEngine( reader.ReadUInt32() );
             }
             while ( chunkId != GameBoxReader.EndMarkerClassId );
 

--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/MediaTracker/MediaTrackerTrianglesChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/MediaTracker/MediaTrackerTrianglesChunk.cs
@@ -5,8 +5,7 @@ using System.Text;
 namespace ManiaPlanetSharp.GameBox.Parsing.Chunks.MediaTracker
 {
     [Chunk(0x03029001)]
-    [Chunk(0x03029002)]
-    public class MediaTrackerTrianglesChunk
+    public class MediaTrackerTrianglesChunk001
     : Chunk
     {
         [Property, Array]
@@ -18,7 +17,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks.MediaTracker
         [Property]
         public uint VerticeCount { get; set; }
 
-        [Property, CustomParserMethod(nameof(MediaTrackerTrianglesChunk.ParseVertices))]
+        [Property, CustomParserMethod(nameof(MediaTrackerTrianglesChunk001.ParseVertices))]
         public Vector3D[][] VerticeLocations { get; set; }
 
         public Vector3D[][] ParseVertices(GameBoxReader reader)
@@ -92,5 +91,13 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks.MediaTracker
     {
         [Property, Array(3)]
         public int[] VerticeIndices { get; set; }
+    }
+
+    [Chunk(0x03029002, Skippable = true)]
+    public class MediaTrackerTrianglesChunk002
+    : Chunk
+    {
+        [Property]
+        public int Unknown { get; set; }
     }
 }


### PR DESCRIPTION
This pull request makes few changes to the repository codebase:

👉 Disable 0x0301b000 chunk. Challenge parameters are archived in the 0x03043011 chunk.
👉 Remap class/chunk id in dedicated node ref functions to correctly parse maps saved with older versions of the game.
👉 Chunk ids are always remapped when parsing body chunks. This change prevents incorrect lookups of the skippable flag when using legacy chunk ids. This is because only non-legacy chunk ids have defined skippable flags.
👉 Separate 0x03029001 and 0x03029002 chunks. I do not know why they were treated as one, but in fact they are completely different chunks, and 0x03029002 is also skippable, which led to huge memory spikes. In this particular case it also caused allocation of an array with 0x534b4950 MediaTrackerTrianglesValue elements.