### PR TITLE
Add support for SM tods

### DIFF
--- a/src/ManiaPlanetSharp/GameBox/Parsing/Utils/ParsedValueMappings.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Utils/ParsedValueMappings.cs
@@ -8,7 +8,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Utils
 {
     public static class ParsedValueMappings
     {
-        private static Regex timeOfDayMappingRegex = new Regex(@"^((?<Modifier>[A-Za-z]*)(\d+x\d+))?(?!$)(?<Mood>[Ss]unrise|[Ss]unset|[Nn]ight|[Dd]ay|$|^)(\d+x?\d*)?$");
+        private static Regex timeOfDayMappingRegex = new Regex(@"^((?<Modifier>[A-Za-z]*)(\d+x\d+))?(?!$)(?<Mood>[Ss]unrise|[Ss]unset|[Nn]ight|[Dd]ay|D$|S$|N$|$|^)(\d+x?\d*)?$");
         public static bool TryMapTimeOfDay(string timeOfDay, out string mappedTimeOfDay)
         {
             /* Real Mappings from TMUF:
@@ -55,6 +55,15 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Utils
              *      NoStadium48x48Day -> Day
              *      NoStadium48x48Night -> Night
              *      etc.
+             *      
+             * Mappings from SMX (arbitrary):
+             *      Water48x48Day -> Day
+             *      Water48x48 -> Day
+             *      Water48x48D -> Day
+             *      Water48x48Sunrise -> Sunrise
+             *      Land48x48D -> Day
+             *      Land48x48S -> Sunset
+             *      
              */
 
             if (string.IsNullOrWhiteSpace(timeOfDay))
@@ -63,7 +72,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Utils
                 return false;
             }
 
-            if (timeOfDay.ToLowerInvariant() == "simple")
+            if (timeOfDay.ToLowerInvariant() == "simple" || timeOfDay == "Water48x48")
             {
                 mappedTimeOfDay = "Day";
                 return true;
@@ -95,13 +104,13 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Utils
                 case var a when a.EndsWith("sunrise"):
                     mappedTimeOfDay = "Sunrise";
                     return true;
-                case var b when b.EndsWith("day"):
+                case var b when b.EndsWith("day") || b.EndsWith("d"):
                     mappedTimeOfDay = "Day";
                     return true;
-                case var c when c.EndsWith("sunset"):
+                case var c when c.EndsWith("sunset") || c.EndsWith("s"):
                     mappedTimeOfDay = "Sunset";
                     return true;
-                case var d when d.EndsWith("night"):
+                case var d when d.EndsWith("night") || d.EndsWith("n"):
                     mappedTimeOfDay = "Night";
                     return true;
             }


### PR DESCRIPTION
Tested with

```
Sunset
Water48x48Night
Land48x48Sunset
Water48x48
Land48x48Night
Day
Water48x48Sunrise
Water48x48Sunset
Sunrise
Land48x48Day
Land48x48Sunrise
Land48x48D
Land48x48N
Water48x48Day
Land48x48S
Night
```

and those from TM2

```
Day64
Night32
Day
Sunset32
64x64Sunset
Sunrise
Night
Day32
Sunset64
64x64Sunrise
64x64Night
Night48
Sunrise48
Night64
Day48
Sunrise64
64x64Sunrise
Sunset
Water48x48Day
64x64Day
Sunset48
48x48Day
Sunrise32
64x64Sunset
```

and those from TM 2020

```
Sunset
48x48Night
48x48Sunset
48x48Screen155Night
48x48Day
Sunrise16x12
NoStadium48x48Sunset
48x48Screen155Sunset
Sunset16x1
48x48Screen155Sunset
48x48Screen155Night
Day
48x48Sunrise
NoStadium48x48Sunrise
48x48Sunset
Night16x12
NoStadium48x48Sunrise
Sunrise
48x48Sunrise
48x48Screen155Day
Day16x12
NoStadium48x48Day
NoStadium48x48Sunset
NoStadium48x48Night
48x48Screen155Sunrise
NoStadium48x48Night
Sunset16x12
48x48Screen155Sunrise
```