### PR TITLE
skip ghost chunk when eventsduration is 0

### DIFF
--- a/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Ghost/GhostChunk.cs
+++ b/src/ManiaPlanetSharp/GameBox/Parsing/Chunks/Ghost/GhostChunk.cs
@@ -14,36 +14,36 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
         [Property]
         public uint EventsDuration { get; set; }
 
-        [Property]
+        [Property, Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public uint Ignored { get; set; }
 
-        [Property(SpecialPropertyType.LookbackString), Array]
+        [Property(SpecialPropertyType.LookbackString), Array, Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public string[] ControlNames { get; set; }
 
         [Property]
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never), Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public uint ControlEntryCount { get; set; }
 
-        [Property]
+        [Property, Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public uint Unknown { get; set; }
 
-        [Property, Array(nameof(ControlEntryCount))]
+        [Property, Array(nameof(ControlEntryCount)), Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public GhostControlEntry[] ControlEntries { get; set; }
 
-        [Property(SpecialPropertyType.LongString)]
+        [Property(SpecialPropertyType.LongString), Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public string GameVersion { get; set; }
 
-        [Property]
+        [Property, Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public uint ExecutableChecksum { get; set; }
 
-        [Property]
+        [Property, Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public uint OSKind { get; set; }
 
-        [Property]
+        [Property, Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public uint CPUKind { get; set; }
 
         private string raceSettingsXmlString;
-        [Property]
+        [Property, Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public string RaceSettingsXmlString
         {
             get
@@ -63,7 +63,7 @@ namespace ManiaPlanetSharp.GameBox.Parsing.Chunks
 
         //public GhostRaceSettingsRoot Root { get; set; }
 
-        [Property]
+        [Property, Condition(nameof(EventsDuration), ConditionOperator.GreaterThan, 0)]
         public uint Unknown2 { get; set; }
     }
 


### PR DESCRIPTION
Uploading this file causes the parser to create a huge array of controlnames and inputs due to invalid array lengths being parsed. The ghost chunk must be skipped in order to avoid memory leaks.

[MapinQuestion.zip](https://github.com/user-attachments/files/18482197/MapinQuestion.zip)

![image](https://github.com/user-attachments/assets/c3cb6963-c228-4d21-82ea-04a8213896f8)
